### PR TITLE
Fix bug introduced by non-standard MRES handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ __ZaberMotionCreateController(port, numAxes, movingPollPeriod, idlePollPeriod, z
 Instantiates `zaberController` with typical `asynMotorController` params and some zaber device-specific params:
 - `zaberPort`: Address or serial port name of zaber device (prefixed with `tcp://` or `serial://`). A serial port can have multiple devices chained together.
 - `zaberDeviceNum`: Number (1-indexed) of the controller device on a device chain. This number is stable unless the device chain is modified. It can be found using [Zaber Launcher](https://software.zaber.com/zaber-launcher/download).
-- `unitsPerStep` (optional): A space-separated list of per-axis values, one per axis in axis order, giving the physical size of one motor-record step in micrometres (linear axes) or degrees (rotary axes). Omitted or short entries default to `1.0`.
+- `unitsPerStep` (optional): The physical size of one motor-record step, expressed as a fraction of micrometres for linear axes, or degrees for rotary axes. This is an axis's resolution floor; shrink it for finer moves (e.g. `1e-6` gives a rotary axis micro-degree resolution, `1e-3` gives a linear device nm resolution). Pass one space-separated value per axis, in axis order. Omitted or short entries default to `1.0` (a 1 µm or 1° step).
 
 __ZaberMotionSetDbPath(path)__
 Allows user to specify the path to a local copy of the [Zaber device database](https://software.zaber.com/motion-library/docs/guides/device_db). This is only necessary if the IOC does not have access to the internet. Download link for current version of device database [here](https://www.zaber.com/software/device-database/devices-public.sqlite.lzma).
@@ -119,7 +119,7 @@ Allows user to specify the path to a local copy of the [Zaber device database](h
 This section is intended to clarify implementation-specific details and limitations for `zaberAxis` and `zaberController`
 
 #### zaberAxis
-Can control either a linear or rotary axis. Motion commands are sent to ZML in micrometres (linear) or degrees (rotary); one motor-record step is `unitsPerStep` of these units. See [Units and resolution](#units-and-resolution) for how this interacts with the record's `MRES` and `EGU` fields.
+Can control either a linear or rotary axis. Motion commands are sent to ZML in micrometres (linear) or degrees (rotary); one motor-record step is `unitsPerStep` of these units (see `ZaberMotionCreateController` above).
 
 __setPosition(position)__:
 Implemented as specified. Performs unit conversion and calls `set pos <native_units>` as defined [here](https://www.zaber.com/protocol-manual#topic_setting_pos) in Zaber ASCII protocol

--- a/README.md
+++ b/README.md
@@ -105,11 +105,11 @@ This module provides a single implementation of both `asynMotorController` and `
 
 ### IOC Shell Functions
 
-__ZaberMotionCreateController(port, numAxes, movingPollPeriod, idlePollPeriod, zaberPort, zaberDeviceNum, [unitsPerStep ...])__
+__ZaberMotionCreateController(port, numAxes, movingPollPeriod, idlePollPeriod, zaberPort, zaberDeviceNum, [stepScaleFactor ...])__
 Instantiates `zaberController` with typical `asynMotorController` params and some zaber device-specific params:
 - `zaberPort`: Address or serial port name of zaber device (prefixed with `tcp://` or `serial://`). A serial port can have multiple devices chained together.
 - `zaberDeviceNum`: Number (1-indexed) of the controller device on a device chain. This number is stable unless the device chain is modified. It can be found using [Zaber Launcher](https://software.zaber.com/zaber-launcher/download).
-- `unitsPerStep` (optional): The physical size of one motor-record step, expressed as a fraction of micrometres for linear axes, or degrees for rotary axes. This is an axis's resolution floor; shrink it for finer moves (e.g. `1e-6` gives a rotary axis micro-degree resolution, `1e-3` gives a linear device nm resolution). Pass one space-separated value per axis, in axis order. Omitted or short entries default to `1.0` (a 1 µm or 1° step).
+- `stepScaleFactor` (optional): Per-axis scaling factors for adjusting the base step size, which is micrometres for linear axes and degrees for rotary axes (e.g. a value of `1e-6` gives a rotary axis micro-degree resolution, `1e-3` gives a linear device nm resolution). Pass one space-separated value per axis, in axis order. Omitted or short entries default to `1.0` (a 1 µm or 1° step size).
 
 __ZaberMotionSetDbPath(path)__
 Allows user to specify the path to a local copy of the [Zaber device database](https://software.zaber.com/motion-library/docs/guides/device_db). This is only necessary if the IOC does not have access to the internet. Download link for current version of device database [here](https://www.zaber.com/software/device-database/devices-public.sqlite.lzma).
@@ -119,7 +119,7 @@ Allows user to specify the path to a local copy of the [Zaber device database](h
 This section is intended to clarify implementation-specific details and limitations for `zaberAxis` and `zaberController`
 
 #### zaberAxis
-Can control either a linear or rotary axis. Motion commands are sent to ZML in micrometres (linear) or degrees (rotary); one motor-record step is `unitsPerStep` of these units (see `ZaberMotionCreateController` above).
+Can control either a linear or rotary axis. Motion commands are passed to devices in microns (linear) or degrees (rotary). One motor-record step is `stepScaleFactor` of these units (see `ZaberMotionCreateController` above).
 
 __setPosition(position)__:
 Implemented as specified. Performs unit conversion and calls `set pos <native_units>` as defined [here](https://www.zaber.com/protocol-manual#topic_setting_pos) in Zaber ASCII protocol

--- a/README.md
+++ b/README.md
@@ -105,10 +105,11 @@ This module provides a single implementation of both `asynMotorController` and `
 
 ### IOC Shell Functions
 
-__ZaberMotionCreateController(port, numAxes, movingPollPeriod, idlePollPeriod, zaberPort, zaberDeviceNum)__
-Instantiates `zaberController` with typical `asynMotorController` params and two zaber device-specific params:
+__ZaberMotionCreateController(port, numAxes, movingPollPeriod, idlePollPeriod, zaberPort, zaberDeviceNum, [unitsPerStep ...])__
+Instantiates `zaberController` with typical `asynMotorController` params and some zaber device-specific params:
 - `zaberPort`: Address or serial port name of zaber device (prefixed with `tcp://` or `serial://`). A serial port can have multiple devices chained together.
 - `zaberDeviceNum`: Number (1-indexed) of the controller device on a device chain. This number is stable unless the device chain is modified. It can be found using [Zaber Launcher](https://software.zaber.com/zaber-launcher/download).
+- `unitsPerStep` (optional): A space-separated list of per-axis values, one per axis in axis order, giving the physical size of one motor-record step in micrometres (linear axes) or degrees (rotary axes). Omitted or short entries default to `1.0`.
 
 __ZaberMotionSetDbPath(path)__
 Allows user to specify the path to a local copy of the [Zaber device database](https://software.zaber.com/motion-library/docs/guides/device_db). This is only necessary if the IOC does not have access to the internet. Download link for current version of device database [here](https://www.zaber.com/software/device-database/devices-public.sqlite.lzma).
@@ -118,7 +119,7 @@ Allows user to specify the path to a local copy of the [Zaber device database](h
 This section is intended to clarify implementation-specific details and limitations for `zaberAxis` and `zaberController`
 
 #### zaberAxis
-Can control either a linear or rotary axis. The units for all motion commands are microns for linear devices and degrees for rotary. Please keep this in mind when configuring motor records.
+Can control either a linear or rotary axis. Motion commands are sent to ZML in micrometres (linear) or degrees (rotary); one motor-record step is `unitsPerStep` of these units. See [Units and resolution](#units-and-resolution) for how this interacts with the record's `MRES` and `EGU` fields.
 
 __setPosition(position)__:
 Implemented as specified. Performs unit conversion and calls `set pos <native_units>` as defined [here](https://www.zaber.com/protocol-manual#topic_setting_pos) in Zaber ASCII protocol

--- a/iocs/zaberMotionIOC/iocBoot/iocZaberMotion/motor.cmd.rotary-stage.zaber
+++ b/iocs/zaberMotionIOC/iocBoot/iocZaberMotion/motor.cmd.rotary-stage.zaber
@@ -8,7 +8,7 @@ dbLoadTemplate("motor.substitutions.rotary-stage.zaber")
 #    idle poll period (ms),
 #    address or serial port name of zaber device (prefixed with tcp:// or serial://),
 #    zaber device number (1-indexed),
-#    per-axis units-per-step (optional; um for linear, deg for rotary; defaults to 1)
+#    (optional) per-axis units-per-step: um for linear, deg for rotary -- defaults to 1
 # )
 ###
 ZaberMotionCreateController("X-RSW", 1, 100, 5000, "serial:///dev/ttyUSB0", 1, 1e-6)

--- a/iocs/zaberMotionIOC/iocBoot/iocZaberMotion/motor.cmd.rotary-stage.zaber
+++ b/iocs/zaberMotionIOC/iocBoot/iocZaberMotion/motor.cmd.rotary-stage.zaber
@@ -7,7 +7,8 @@ dbLoadTemplate("motor.substitutions.rotary-stage.zaber")
 #    moving poll period (ms),
 #    idle poll period (ms),
 #    address or serial port name of zaber device (prefixed with tcp:// or serial://),
-#    zaber device number (1-indexed)
+#    zaber device number (1-indexed),
+#    per-axis units-per-step (optional; um for linear, deg for rotary; defaults to 1)
 # )
 ###
-ZaberMotionCreateController("X-RSW", 1, 100, 5000, "serial:///dev/ttyUSB0", 1)
+ZaberMotionCreateController("X-RSW", 1, 100, 5000, "serial:///dev/ttyUSB0", 1, 1e-6)

--- a/iocs/zaberMotionIOC/iocBoot/iocZaberMotion/motor.cmd.rotary-stage.zaber
+++ b/iocs/zaberMotionIOC/iocBoot/iocZaberMotion/motor.cmd.rotary-stage.zaber
@@ -8,7 +8,7 @@ dbLoadTemplate("motor.substitutions.rotary-stage.zaber")
 #    idle poll period (ms),
 #    address or serial port name of zaber device (prefixed with tcp:// or serial://),
 #    zaber device number (1-indexed),
-#    (optional) per-axis units-per-step: um for linear, deg for rotary -- defaults to 1
+#    (optional) per-axis step scale factor: um for linear, deg for rotary -- defaults to 1
 # )
 ###
 ZaberMotionCreateController("X-RSW", 1, 100, 5000, "serial:///dev/ttyUSB0", 1, 1e-6)

--- a/iocs/zaberMotionIOC/iocBoot/iocZaberMotion/motor.substitutions.rotary-stage.zaber
+++ b/iocs/zaberMotionIOC/iocBoot/iocZaberMotion/motor.substitutions.rotary-stage.zaber
@@ -1,8 +1,6 @@
 file "$(MOTOR)/motorApp/Db/asyn_motor.db"
 {
   pattern
-  # MRES sets the readback/command resolution in degrees (the driver scales
-  # ZML moves by MRES). 0.001 => millidegree resolution; lower it for finer.
   {P,             N,          M,        DTYP,    PORT, ADDR,            DESC, EGU, DIR,  VELO, VBAS, ACCL, BDST, BVEL, BACC,  MRES, PREC, DLLM, DHLM, INIT}
-  {ROTARY_STAGE:, 1, "axis$(N)", "asynMotor",   X-RSW,    0, "Rotary Axis 1", deg, Pos,  10.0,  1.0,  0.5,    0,    1,  0.2, 0.001,    4, -360,  360,   ""}
+  {ROTARY_STAGE:, 1, "axis$(N)", "asynMotor",   X-RSW,    0, "Rotary Axis 1", deg, Pos,  10.0,  1.0,  0.5,    0,    1,  0.2, 1e-6,    4, -360,  360,   ""}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dev = [
     "pytest-asyncio",
     "pyright",
     "ruff~=0.14.0",
-    "zaber-ascii-mock~=0.1.2",
+    "zaber-ascii-mock~=0.2.0",
 ]
 
 [tool.uv.sources]
@@ -41,11 +41,9 @@ extend = "zaber-python-tooling-config/zaber-ruff.toml"
 
 [tool.pyright]
 extends = "zaber-python-tooling-config/zaber-pyright.toml"
-extraPaths = ["tests"]
 stubPath = "tests/typings"
 
 [tool.pytest.ini_options]
-pythonpath = ["tests"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 asyncio_default_test_loop_scope = "session"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -17,6 +17,7 @@ from zaber_ascii_mock import MockDevice
 from zaber_ascii_mock.devices import xmcc4
 from zaber_ascii_mock.mock_device import WriteLineFn
 from zaber_ascii_mock.protocol import Command
+from zaber_ascii_mock.server import _default_port
 
 from tests.e2e.ioc_helpers import render_st_cmd, start_ioc, stop_ioc, wait_for_ioc_ready
 from tests.e2e.pvt_handler import PvtHandler
@@ -66,14 +67,27 @@ async def command_log(mock_device: MockDevice) -> list[str]:
 
 
 @pytest_asyncio.fixture(scope="session")
+async def rotary_mock_device() -> AsyncGenerator[MockDevice, None]:
+    """Provide a MockDevice posing as an X-MCC4 with four rotary axes."""
+    # Distinct port from the session mock_device (which uses the default) so both coexist.
+    async with MockDevice(
+        device_number=1, info=xmcc4.FW7_38_FOUR_ROTARY, port=_default_port() + 1
+    ) as mock:
+        yield mock
+
+
+@pytest_asyncio.fixture(scope="session")
 async def ioc_process(
     mock_device: MockDevice,
+    rotary_mock_device: MockDevice,
     pvt_handler: PvtHandler,  # noqa: ARG001  # ensure handler is registered before IOC connects
     command_log: list[str],  # noqa: ARG001  # ensure command tap is registered before IOC connects
     tmp_path_factory: pytest.TempPathFactory,
 ) -> AsyncGenerator[subprocess.Popen[bytes], None]:
-    """Start a real IOC pointed at mock_device and yield the process handle."""
-    st_cmd = render_st_cmd(tmp_path_factory.mktemp("ioc"), mock_device.port)
+    """Start a real IOC pointed at two mock devices."""
+    st_cmd = render_st_cmd(
+        tmp_path_factory.mktemp("ioc"), mock_device.port, rotary_mock_device.port
+    )
     proc = start_ioc(st_cmd)
     try:
         await wait_for_ioc_ready()
@@ -81,6 +95,18 @@ async def ioc_process(
     finally:
         stop_ioc(proc)
         purge_channel_caches()
+
+
+@pytest_asyncio.fixture
+async def reset_rotary_state(rotary_mock_device: MockDevice) -> None:
+    """Restore the rotary mock's axes to a clean state before each test that uses it."""
+    for axis in rotary_mock_device._axes.values():  # noqa: SLF001
+        axis.position = 0.0
+        axis.is_busy = False
+        axis.is_homed = False
+        axis.warnings.clear()
+        axis._target_position = None  # noqa: SLF001
+        axis._move_done = None  # noqa: SLF001
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -69,7 +69,6 @@ async def command_log(mock_device: MockDevice) -> list[str]:
 @pytest_asyncio.fixture(scope="session")
 async def rotary_mock_device() -> AsyncGenerator[MockDevice, None]:
     """Provide a MockDevice posing as an X-MCC4 with four rotary axes."""
-    # Distinct port from the session mock_device (which uses the default) so both coexist.
     async with MockDevice(
         device_number=1, info=xmcc4.FW7_38_FOUR_ROTARY, port=_default_port() + 1
     ) as mock:

--- a/tests/e2e/ioc_helpers.py
+++ b/tests/e2e/ioc_helpers.py
@@ -31,10 +31,14 @@ zaberMotion_registerRecordDeviceDriver pdbbase
 dbLoadRecords("${{MOTOR}}/db/motorUtil.db", "P=zaberMotion:")
 dbLoadTemplate("{linear_substitutions}")
 # Fast idle poll (100 ms) so status/warning-flag tests don't wait on a slow poll cycle.
-ZaberMotionCreateController("XMCC_LINEAR", 4, 50, 100, "tcp://127.0.0.1:{port}", 1, 1.0 1.0 1.0 0.001)
+ZaberMotionCreateController( \
+    "XMCC_LINEAR", 4, 50, 100, "tcp://127.0.0.1:{linear_port}", 1, 1.0 1.0 1.0 0.001 \
+)
 ZaberControllerCreateProfile("XMCC_LINEAR", 50)
 dbLoadTemplate("{rotary_substitutions}")
-ZaberMotionCreateController("XMCC_ROTARY", 4, 50, 100, "tcp://127.0.0.1:{rotary_port}", 1, 1e-6 1e-6 1e-6 1e-6)
+ZaberMotionCreateController( \
+    "XMCC_ROTARY", 4, 50, 100, "tcp://127.0.0.1:{rotary_port}", 1, 1e-6 1e-6 1e-6 1e-6 \
+)
 iocInit
 motorUtilInit("zaberMotion:")
 """
@@ -44,11 +48,11 @@ _LINEAR_SUBSTITUTIONS = _SUBSTITUTIONS_DIR / "motor.substitutions.linear-test.za
 _ROTARY_SUBSTITUTIONS = _SUBSTITUTIONS_DIR / "motor.substitutions.rotary-test.zaber"
 
 
-def render_st_cmd(tmp_path: Path, port: int, rotary_port: int) -> Path:
-    """Write a startup script (linear XMCC_LINEAR + mixed XMCC_ROTARY controllers) and return its path."""
+def render_st_cmd(tmp_path: Path, linear_port: int, rotary_port: int) -> Path:
+    """Write a startup script (linear + rotary controllers) and return its path."""
     content = _ST_CMD_TEMPLATE.format(
         envpaths=_ENV_PATHS,
-        port=port,
+        linear_port=linear_port,
         rotary_port=rotary_port,
         linear_substitutions=_LINEAR_SUBSTITUTIONS,
         rotary_substitutions=_ROTARY_SUBSTITUTIONS,

--- a/tests/e2e/ioc_helpers.py
+++ b/tests/e2e/ioc_helpers.py
@@ -22,25 +22,37 @@ _ENV_PATHS = _IOC_ROOT / "iocBoot/iocZaberMotion/envPaths"
 # PV that becomes readable once iocInit and motorUtilInit have completed.
 _READY_PV = "zaberMotion:alldone"
 
+# One IOC with two controllers: an X-MCC with linear stages, and one with rotary stages.
 _ST_CMD_TEMPLATE = """\
 < {envpaths}
 cd "${{TOP}}"
 dbLoadDatabase "dbd/zaberMotion.dbd"
 zaberMotion_registerRecordDeviceDriver pdbbase
 dbLoadRecords("${{MOTOR}}/db/motorUtil.db", "P=zaberMotion:")
-cd "${{TOP}}/iocBoot/${{IOC}}"
-dbLoadTemplate("motor.substitutions.xy-stage.zaber")
+dbLoadTemplate("{linear_substitutions}")
 # Fast idle poll (100 ms) so status/warning-flag tests don't wait on a slow poll cycle.
-ZaberMotionCreateController("XMCC2", 2, 50, 100, "tcp://127.0.0.1:{port}", 1)
-ZaberControllerCreateProfile("XMCC2", 50)
+ZaberMotionCreateController("XMCC_LINEAR", 4, 50, 100, "tcp://127.0.0.1:{port}", 1, 1.0 1.0 1.0 0.001)
+ZaberControllerCreateProfile("XMCC_LINEAR", 50)
+dbLoadTemplate("{rotary_substitutions}")
+ZaberMotionCreateController("XMCC_ROTARY", 4, 50, 100, "tcp://127.0.0.1:{rotary_port}", 1, 1e-6 1e-6 1e-6 1e-6)
 iocInit
 motorUtilInit("zaberMotion:")
 """
 
+_SUBSTITUTIONS_DIR = Path(__file__).parent / "substitutions"
+_LINEAR_SUBSTITUTIONS = _SUBSTITUTIONS_DIR / "motor.substitutions.linear-test.zaber"
+_ROTARY_SUBSTITUTIONS = _SUBSTITUTIONS_DIR / "motor.substitutions.rotary-test.zaber"
 
-def render_st_cmd(tmp_path: Path, port: int) -> Path:
-    """Write a custom startup script to tmp_path and return its path."""
-    content = _ST_CMD_TEMPLATE.format(envpaths=_ENV_PATHS, port=port)
+
+def render_st_cmd(tmp_path: Path, port: int, rotary_port: int) -> Path:
+    """Write a startup script (linear XMCC_LINEAR + mixed XMCC_ROTARY controllers) and return its path."""
+    content = _ST_CMD_TEMPLATE.format(
+        envpaths=_ENV_PATHS,
+        port=port,
+        rotary_port=rotary_port,
+        linear_substitutions=_LINEAR_SUBSTITUTIONS,
+        rotary_substitutions=_ROTARY_SUBSTITUTIONS,
+    )
     st_cmd = tmp_path / "st.cmd"
     st_cmd.write_text(content)
     return st_cmd

--- a/tests/e2e/mock_helpers.py
+++ b/tests/e2e/mock_helpers.py
@@ -1,0 +1,48 @@
+"""Helpers for driving the mock device during e2e tests."""
+
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator
+
+from zaber_ascii_mock import MockDevice
+
+from tests.e2e.ca_helpers import put
+
+# Linear resolution of the mock's stage (native microsteps per mm).
+STEPS_PER_MM = 8062.992125984
+
+
+def microsteps(position_mm: float) -> int:
+    """Native microstep target the driver sends for a position in mm."""
+    return round(position_mm * STEPS_PER_MM)
+
+
+def roundtrip_mm(position_mm: float) -> float:
+    """Return a position in mm after native-microstep quantization."""
+    return microsteps(position_mm) / STEPS_PER_MM
+
+
+@contextlib.asynccontextmanager
+async def completing_moves(mock: MockDevice) -> AsyncIterator[None]:
+    """Complete in-progress mock moves so blocking motions finish."""
+    stop = asyncio.Event()
+
+    async def run() -> None:
+        while not stop.is_set():
+            for ax in mock._axes.values():  # noqa: SLF001
+                if ax.is_busy:
+                    ax.complete_move()
+            await asyncio.sleep(0.02)
+
+    task = asyncio.create_task(run())
+    try:
+        yield
+    finally:
+        stop.set()
+        await task
+
+
+async def move(pv: str, value: float, mock: MockDevice) -> None:
+    """Command an absolute move (write VAL) and block until it completes."""
+    async with completing_moves(mock):
+        await put(f"{pv}.VAL", value, wait=True, timeout=20)

--- a/tests/e2e/mock_helpers.py
+++ b/tests/e2e/mock_helpers.py
@@ -8,8 +8,8 @@ from zaber_ascii_mock import MockDevice
 
 from tests.e2e.ca_helpers import put
 
-# Linear resolution of the mock's stage (native microsteps per mm).
 STEPS_PER_MM = 8062.992125984
+"""Linear resolution of the mock's stage (native microsteps per mm)."""
 
 
 def microsteps(position_mm: float) -> int:

--- a/tests/e2e/profile_helpers.py
+++ b/tests/e2e/profile_helpers.py
@@ -9,9 +9,6 @@ P = "IOC:MyProfile:"
 M1 = "M1"
 M2 = "M2"
 
-STEPS_PER_MM = 8062.992125984
-"""Steps per mm for the mock's X-LHM linear peripheral at resolution 64."""
-
 # Profile move status codes (from asynMotorController.h: ProfileStatus enum).
 STATUS_SUCCESS = 1
 STATUS_FAILURE = 2

--- a/tests/e2e/substitutions/motor.substitutions.linear-test.zaber
+++ b/tests/e2e/substitutions/motor.substitutions.linear-test.zaber
@@ -1,0 +1,31 @@
+file "$(MOTOR)/motorApp/Db/asyn_motor.db"
+{
+  pattern
+  {P,            N, M,          DTYP,        PORT,        ADDR, DESC,        EGU, DIR, VELO,  VBAS, ACCL, BDST, BVEL, BACC, MRES,  PREC, DLLM, DHLM,   INIT}
+  {LINEAR_TEST:, 1, "axis$(N)", "asynMotor", XMCC_LINEAR, 0,    "Axis 1 mm", mm,  Pos, 20,    5,    0.5,  0,    1,    0.2,  0.001, 3,    0,    100,    ""}
+  {LINEAR_TEST:, 2, "axis$(N)", "asynMotor", XMCC_LINEAR, 1,    "Axis 2 mm", mm,  Pos, 20,    5,    0.5,  0,    1,    0.2,  0.001, 3,    0,    120,    ""}
+  {LINEAR_TEST:, 3, "axis$(N)", "asynMotor", XMCC_LINEAR, 2,    "Axis 3 um", um,  Pos, 20000, 5000, 0.5,  0,    1,    0.2,  1.0,   1,    0,    100000, ""}
+  {LINEAR_TEST:, 4, "axis$(N)", "asynMotor", XMCC_LINEAR, 3,    "Axis 4 nm", mm,  Pos, 20,    5,    0.5,  0,    1,    0.2,  1e-6,  6,    0,    100,    ""}
+}
+
+file "$(TOP)/db/profileMoveController.template"
+{
+  pattern
+  {P,     R,          PORT,  NAXES, NPOINTS, NPULSES, TIMEOUT}
+  {IOC:, MyProfile:, XMCC_LINEAR,      2,      50,      50,     120}
+}
+
+file "$(TOP)/db/profileMoveControllerZaber.template"
+{
+  pattern
+  {P,     R,          PORT, TIMEOUT}
+  {IOC:, MyProfile:, XMCC_LINEAR,     120}
+}
+
+file "$(TOP)/db/profileMoveAxis.template"
+{
+  pattern
+  {P,     R,         M,  PORT,  ADDR, NPOINTS, NREADBACK,              MOTOR, PREC, TIMEOUT}
+  {IOC:, MyProfile:, 1, XMCC_LINEAR,    0,       50,        50,  LINEAR_TEST:axis1,    3,     120}
+  {IOC:, MyProfile:, 2, XMCC_LINEAR,    1,       50,        50,  LINEAR_TEST:axis2,    3,     120}
+}

--- a/tests/e2e/substitutions/motor.substitutions.rotary-test.zaber
+++ b/tests/e2e/substitutions/motor.substitutions.rotary-test.zaber
@@ -1,0 +1,9 @@
+file "$(MOTOR)/motorApp/Db/asyn_motor.db"
+{
+  pattern
+  {P,            N, M,          DTYP,        PORT,      ADDR,   DESC,          EGU,    DIR, VELO,   VBAS,  ACCL, BDST, BVEL, BACC, MRES,                PREC, DLLM,        DHLM,       INIT}
+  {ROTARY_TEST:, 1, "axis$(N)", "asynMotor", XMCC_ROTARY, 0,    "deg",         deg,    Pos, 20,     5,     0.5,  0,    1,    0.2,  1e-6,                4,    -360,        360,        ""}
+  {ROTARY_TEST:, 2, "axis$(N)", "asynMotor", XMCC_ROTARY, 1,    "millideg",    mdeg,   Pos, 20000,  5000,  0.5,  0,    1,    0.2,  1e-3,                1,    -360000,     360000,     ""}
+  {ROTARY_TEST:, 3, "axis$(N)", "asynMotor", XMCC_ROTARY, 2,    "radian",      rad,    Pos, 0.35,   0.087, 0.5,  0,    1,    0.2,  1.7453292519943e-8,  8,    -6.2831853,  6.2831853,  ""}
+  {ROTARY_TEST:, 4, "axis$(N)", "asynMotor", XMCC_ROTARY, 3,    "arcsec",      arcsec, Pos, 72000,  18000, 0.5,  0,    1,    0.2,  3.6e-3,              1,    -1296000,    1296000,    ""}
+}

--- a/tests/e2e/test_basic_motion.py
+++ b/tests/e2e/test_basic_motion.py
@@ -8,7 +8,7 @@ import pytest
 from zaber_ascii_mock import MockDevice
 
 from tests.e2e.ca_helpers import get_float, get_int, put
-from tests.e2e.profile_helpers import STEPS_PER_MM
+from tests.e2e.mock_helpers import completing_moves, microsteps
 
 _AXIS = "LINEAR_TEST:axis1"
 """LINEAR_TEST:axis1 motor record from motor.substitutions.xy-stage.zaber (EGU = mm)."""
@@ -22,31 +22,6 @@ _MSTA_HIGH_LIMIT = 0x4        # RA_PLUS_LS
 _MSTA_FOLLOWING_ERROR = 0x40  # EA_SLIP_STALL
 _MSTA_PROBLEM = 0x200         # RA_PROBLEM
 _MSTA_LOW_LIMIT = 0x2000      # RA_MINUS_LS
-
-@contextlib.asynccontextmanager
-async def _completing_moves(mock: MockDevice) -> AsyncIterator[None]:
-    """Complete in-progress mock moves so blocking motions finish."""
-    stop = asyncio.Event()
-
-    async def run() -> None:
-        while not stop.is_set():
-            for ax in mock._axes.values():  # noqa: SLF001
-                if ax.is_busy:
-                    ax.complete_move()
-            await asyncio.sleep(0.02)
-
-    task = asyncio.create_task(run())
-    try:
-        yield
-    finally:
-        stop.set()
-        await task
-
-
-def _microsteps(position_mm: float) -> int:
-    """Return the native microstep target the driver sends for a position in mm."""
-    return round(position_mm * STEPS_PER_MM)
-
 
 async def _wait_until(check: Callable[[], bool], *, timeout: float = 10.0) -> None:
     """Poll a synchronous predicate until true, raising TimeoutError past the deadline."""
@@ -93,10 +68,10 @@ async def _active_warnings(mock: MockDevice, flags: set[str]) -> AsyncIterator[N
 @pytest.mark.usefixtures("ioc_process")
 async def test_absolute_move(mock_device: MockDevice) -> None:
     """Writing to VAL performs an absolute move."""
-    async with _completing_moves(mock_device):
+    async with completing_moves(mock_device):
         await put(f"{_AXIS}.VAL", 5.0, wait=True, timeout=30)
 
-    assert mock_device.axis(1).position == _microsteps(5.0)
+    assert mock_device.axis(1).position == microsteps(5.0)
     assert abs(await get_float(f"{_AXIS}.RBV") - 5.0) < 1e-9
     assert await get_int(f"{_AXIS}.DMOV") == 1
 
@@ -105,11 +80,11 @@ async def test_absolute_move(mock_device: MockDevice) -> None:
 @pytest.mark.usefixtures("ioc_process")
 async def test_relative_move(mock_device: MockDevice) -> None:
     """Writing to RLV performs a relative move."""
-    async with _completing_moves(mock_device):
+    async with completing_moves(mock_device):
         await put(f"{_AXIS}.VAL", 5.0, wait=True, timeout=30)   # start at 5 mm
         await put(f"{_AXIS}.RLV", 2.0, wait=True, timeout=30)   # end at 7 mm
 
-    assert mock_device.axis(1).position == _microsteps(7.0)
+    assert mock_device.axis(1).position == microsteps(7.0)
     assert abs(await get_float(f"{_AXIS}.RBV") - 7.0) < 1e-9
 
 
@@ -117,9 +92,9 @@ async def test_relative_move(mock_device: MockDevice) -> None:
 @pytest.mark.usefixtures("ioc_process")
 async def test_home(mock_device: MockDevice) -> None:
     """Writing to HOMF homes the axis and sets the homed status bit."""
-    mock_device.axis(1).position = _microsteps(5.0) # start away from home
+    mock_device.axis(1).position = microsteps(5.0) # start away from home
 
-    async with _completing_moves(mock_device):
+    async with completing_moves(mock_device):
         await put(f"{_AXIS}.HOMF", 1, wait=True, timeout=30)
 
     assert mock_device.axis(1).position == 0

--- a/tests/e2e/test_basic_motion.py
+++ b/tests/e2e/test_basic_motion.py
@@ -10,8 +10,8 @@ from zaber_ascii_mock import MockDevice
 from tests.e2e.ca_helpers import get_float, get_int, put
 from tests.e2e.profile_helpers import STEPS_PER_MM
 
-_AXIS = "XY_STAGE:axis1"
-"""XY_STAGE:axis1 motor record from motor.substitutions.xy-stage.zaber (EGU = mm)."""
+_AXIS = "LINEAR_TEST:axis1"
+"""LINEAR_TEST:axis1 motor record from motor.substitutions.xy-stage.zaber (EGU = mm)."""
 
 # MSTA status bits (from motor.h msta_field), set by zaberAxis::poll from ZML warning flags.
 #

--- a/tests/e2e/test_linear_units.py
+++ b/tests/e2e/test_linear_units.py
@@ -1,97 +1,46 @@
-"""E2e tests for linear EGU / unitsPerStep interpretation.
-
-Runs against the XMCC_LINEAR controller from motor.substitutions.linear-test.zaber,
-created with per-axis unitsPerStep "1.0 1.0 1.0 0.001":
-
-  axis1  EGU=mm,  MRES=0.001, unitsPerStep=1.0    (baseline, 1 um step)
-  axis3  EGU=um,  MRES=1.0,   unitsPerStep=1.0    (different EGU via MRES)
-  axis4  EGU=mm,  MRES=1e-6,  unitsPerStep=0.001  (1 nm step, sub-micron resolution)
-
-All three drive the same physical linear stage, so a given real-world position
-maps to the same native microstep count regardless of EGU or step size.
-"""
-
-import asyncio
-import contextlib
-from collections.abc import AsyncIterator
+"""E2e tests for linear EGU / stepScaleFactor interpretation."""
 
 import pytest
 from zaber_ascii_mock import MockDevice
 
-from tests.e2e.ca_helpers import get_float, put
+from tests.e2e.ca_helpers import get_float
+from tests.e2e.mock_helpers import microsteps, move, roundtrip_mm
 
 pytestmark = pytest.mark.usefixtures("ioc_process")
 
-STEPS_PER_MM = 8062.992125984
-
-_MM_AXIS = "LINEAR_TEST:axis1"    # EGU = mm, unitsPerStep = 1.0
-_UM_AXIS = "LINEAR_TEST:axis3"    # EGU = um, unitsPerStep = 1.0
-_NM_AXIS = "LINEAR_TEST:axis4"    # EGU = mm, unitsPerStep = 0.001 (1 nm step)
-
-
-def _microsteps(position_mm: float) -> int:
-    """Native microstep target the driver sends for a physical position in mm."""
-    return round(position_mm * STEPS_PER_MM)
-
-
-def _roundtrip_mm(position_mm: float) -> float:
-    """Physical mm after native-microstep quantization."""
-    return _microsteps(position_mm) / STEPS_PER_MM
-
-
-@contextlib.asynccontextmanager
-async def _completing_moves(mock: MockDevice) -> AsyncIterator[None]:
-    """Complete in-progress mock moves so blocking motions finish."""
-    stop = asyncio.Event()
-
-    async def run() -> None:
-        while not stop.is_set():
-            for ax in mock._axes.values():  # noqa: SLF001
-                if ax.is_busy:
-                    ax.complete_move()
-            await asyncio.sleep(0.02)
-
-    task = asyncio.create_task(run())
-    try:
-        yield
-    finally:
-        stop.set()
-        await task
-
-
-async def _move(pv: str, value: float, mock: MockDevice) -> None:
-    async with _completing_moves(mock):
-        await put(f"{pv}.VAL", value, wait=True, timeout=20)
+_MM_AXIS = "LINEAR_TEST:axis1"    # EGU = mm, stepScaleFactor = 1.0
+_UM_AXIS = "LINEAR_TEST:axis3"    # EGU = um, stepScaleFactor = 1.0
+_NM_AXIS = "LINEAR_TEST:axis4"    # EGU = mm, stepScaleFactor = 0.001 (1 nm step)
 
 
 async def test_millimetre_axis_baseline(mock_device: MockDevice) -> None:
     """Baseline mm axis: 5 mm -> the expected native microsteps."""
-    await _move(_MM_AXIS, 5.0, mock_device)
+    await move(_MM_AXIS, 5.0, mock_device)
 
-    assert mock_device.axis(1).position == _microsteps(5.0)
-    assert abs(await get_float(f"{_MM_AXIS}.RBV") - 5.0) < 1e-3
+    assert mock_device.axis(1).position == microsteps(5.0)
+    assert abs(await get_float(f"{_MM_AXIS}.RBV") - 5.0) < 1e-12
 
 
 async def test_micron_egu_axis(mock_device: MockDevice) -> None:
     """EGU=um via MRES: 5000 um reaches the same physical position as 5 mm."""
-    await _move(_UM_AXIS, 5000.0, mock_device)
+    await move(_UM_AXIS, 5000.0, mock_device)
 
-    assert mock_device.axis(3).position == _microsteps(5.0)
+    assert mock_device.axis(3).position == microsteps(5.0)
     # RBV back in micrometres, within one native microstep.
-    assert abs(await get_float(f"{_UM_AXIS}.RBV") - _roundtrip_mm(5.0) * 1000.0) < 0.2
+    assert abs(await get_float(f"{_UM_AXIS}.RBV") - roundtrip_mm(5.0) * 1000.0) < 0.2
 
 
 async def test_nanometre_step_axis_reaches_same_position(mock_device: MockDevice) -> None:
-    """unitsPerStep=0.001 (1 nm step) with MRES=1e-6 still maps 5 mm correctly."""
-    await _move(_NM_AXIS, 5.0, mock_device)
+    """stepScaleFactor=0.001 (1 nm step) with MRES=1e-6 still maps 5 mm correctly."""
+    await move(_NM_AXIS, 5.0, mock_device)
 
-    assert mock_device.axis(4).position == _microsteps(5.0)
-    assert abs(await get_float(f"{_NM_AXIS}.RBV") - _roundtrip_mm(5.0)) < 1e-4
+    assert mock_device.axis(4).position == microsteps(5.0)
+    assert abs(await get_float(f"{_NM_AXIS}.RBV") - roundtrip_mm(5.0)) < 1e-4
 
 
 async def test_nanometre_step_resolves_sub_micron(mock_device: MockDevice) -> None:
     """The 1 nm step resolves a 0.5 um move that the 1 um-step axis would round away."""
-    await _move(_NM_AXIS, 0.0005, mock_device)  # 0.5 um
+    await move(_NM_AXIS, 0.0005, mock_device)  # 0.5 um
 
-    assert mock_device.axis(4).position == _microsteps(0.0005)
+    assert mock_device.axis(4).position == microsteps(0.0005)
     assert mock_device.axis(4).position != 0

--- a/tests/e2e/test_linear_units.py
+++ b/tests/e2e/test_linear_units.py
@@ -1,0 +1,97 @@
+"""E2e tests for linear EGU / unitsPerStep interpretation.
+
+Runs against the XMCC_LINEAR controller from motor.substitutions.linear-test.zaber,
+created with per-axis unitsPerStep "1.0 1.0 1.0 0.001":
+
+  axis1  EGU=mm,  MRES=0.001, unitsPerStep=1.0    (baseline, 1 um step)
+  axis3  EGU=um,  MRES=1.0,   unitsPerStep=1.0    (different EGU via MRES)
+  axis4  EGU=mm,  MRES=1e-6,  unitsPerStep=0.001  (1 nm step, sub-micron resolution)
+
+All three drive the same physical linear stage, so a given real-world position
+maps to the same native microstep count regardless of EGU or step size.
+"""
+
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator
+
+import pytest
+from zaber_ascii_mock import MockDevice
+
+from tests.e2e.ca_helpers import get_float, put
+
+pytestmark = pytest.mark.usefixtures("ioc_process")
+
+STEPS_PER_MM = 8062.992125984
+
+_MM_AXIS = "LINEAR_TEST:axis1"    # EGU = mm, unitsPerStep = 1.0
+_UM_AXIS = "LINEAR_TEST:axis3"    # EGU = um, unitsPerStep = 1.0
+_NM_AXIS = "LINEAR_TEST:axis4"    # EGU = mm, unitsPerStep = 0.001 (1 nm step)
+
+
+def _microsteps(position_mm: float) -> int:
+    """Native microstep target the driver sends for a physical position in mm."""
+    return round(position_mm * STEPS_PER_MM)
+
+
+def _roundtrip_mm(position_mm: float) -> float:
+    """Physical mm after native-microstep quantization."""
+    return _microsteps(position_mm) / STEPS_PER_MM
+
+
+@contextlib.asynccontextmanager
+async def _completing_moves(mock: MockDevice) -> AsyncIterator[None]:
+    """Complete in-progress mock moves so blocking motions finish."""
+    stop = asyncio.Event()
+
+    async def run() -> None:
+        while not stop.is_set():
+            for ax in mock._axes.values():  # noqa: SLF001
+                if ax.is_busy:
+                    ax.complete_move()
+            await asyncio.sleep(0.02)
+
+    task = asyncio.create_task(run())
+    try:
+        yield
+    finally:
+        stop.set()
+        await task
+
+
+async def _move(pv: str, value: float, mock: MockDevice) -> None:
+    async with _completing_moves(mock):
+        await put(f"{pv}.VAL", value, wait=True, timeout=20)
+
+
+async def test_millimetre_axis_baseline(mock_device: MockDevice) -> None:
+    """Baseline mm axis: 5 mm -> the expected native microsteps."""
+    await _move(_MM_AXIS, 5.0, mock_device)
+
+    assert mock_device.axis(1).position == _microsteps(5.0)
+    assert abs(await get_float(f"{_MM_AXIS}.RBV") - 5.0) < 1e-3
+
+
+async def test_micron_egu_axis(mock_device: MockDevice) -> None:
+    """EGU=um via MRES: 5000 um reaches the same physical position as 5 mm."""
+    await _move(_UM_AXIS, 5000.0, mock_device)
+
+    assert mock_device.axis(3).position == _microsteps(5.0)
+    # RBV back in micrometres, within one native microstep.
+    assert abs(await get_float(f"{_UM_AXIS}.RBV") - _roundtrip_mm(5.0) * 1000.0) < 0.2
+
+
+async def test_nanometre_step_axis_reaches_same_position(mock_device: MockDevice) -> None:
+    """unitsPerStep=0.001 (1 nm step) with MRES=1e-6 still maps 5 mm correctly."""
+    await _move(_NM_AXIS, 5.0, mock_device)
+
+    assert mock_device.axis(4).position == _microsteps(5.0)
+    assert abs(await get_float(f"{_NM_AXIS}.RBV") - _roundtrip_mm(5.0)) < 1e-4
+
+
+async def test_nanometre_step_resolves_sub_micron(mock_device: MockDevice) -> None:
+    """The 1 nm step resolves a 0.5 um move that the 1 um-step axis would round away."""
+    await _move(_NM_AXIS, 0.0005, mock_device)  # 0.5 um
+
+    assert mock_device.axis(4).position == _microsteps(0.0005)
+    assert mock_device.axis(4).position != 0

--- a/tests/e2e/test_profile_run.py
+++ b/tests/e2e/test_profile_run.py
@@ -3,11 +3,11 @@
 import pytest
 
 from tests.e2e.ca_helpers import get_float_array, get_int, get_message, put, wait_until_done
+from tests.e2e.mock_helpers import roundtrip_mm
 from tests.e2e.profile_helpers import (
     M1,
     M2,
     STATUS_SUCCESS,
-    STEPS_PER_MM,
     P,
     PulseParams,
     assert_build_succeeds,
@@ -28,10 +28,6 @@ _AXIS2_POSITIONS = [20.0, 20.0, 20.0, 20.0]
 # The points that carry pulses (1-based StartPulses..EndPulses → indices 1, 2).
 _AXIS1_PULSE_POSITIONS = [11.0, 12.0]
 _AXIS2_PULSE_POSITIONS = [20.0, 20.0]
-
-def _microstep_roundtrip(position_mm: float) -> float:
-    """Quantize a position to the nearest microstep, exactly as readbackProfile does."""
-    return round(position_mm * STEPS_PER_MM) / STEPS_PER_MM
 
 
 async def _build_profile_with_pulses() -> None:
@@ -91,16 +87,16 @@ async def test_readback_profile_quantizes_pulse_positions() -> None:
 
     # Each readback must equal the requested position quantized to the nearest microstep.
     for got, req in zip(m1_readbacks, _AXIS1_PULSE_POSITIONS, strict=True):
-        assert abs(got - _microstep_roundtrip(req)) < 1e-12, (
+        assert abs(got - roundtrip_mm(req)) < 1e-12, (
             f"M1 readback {got} != microstep round-trip of {req}"
         )
     for got, req in zip(m2_readbacks, _AXIS2_PULSE_POSITIONS, strict=True):
-        assert abs(got - _microstep_roundtrip(req)) < 1e-12, (
+        assert abs(got - roundtrip_mm(req)) < 1e-12, (
             f"M2 readback {got} != microstep round-trip of {req}"
         )
 
     # FollowingError is the quantization error: (quantized position) - requested.
     for err, req in zip(m1_errors, _AXIS1_PULSE_POSITIONS, strict=True):
-        assert abs(err - (_microstep_roundtrip(req) - req)) < 1e-12, (
+        assert abs(err - (roundtrip_mm(req) - req)) < 1e-12, (
             f"M1 error {err} != expected quantization error for {req}"
         )

--- a/tests/e2e/test_rotary_units.py
+++ b/tests/e2e/test_rotary_units.py
@@ -10,22 +10,24 @@ from tests.e2e.mock_helpers import completing_moves, move
 
 pytestmark = pytest.mark.usefixtures("ioc_process", "reset_rotary_state")
 
-# Native microsteps per degree for the mock's rotary peripheral (46657): a 0.5 deg
-# move lands at 3200 microsteps, i.e. 6400 microsteps/deg.
 MICROSTEPS_PER_DEG = 6400
+"""Native microsteps per degree for the mock's rotary peripheral (46657).
+
+A 0.5 deg move lands at 3200 microsteps, i.e. 6400 microsteps/deg.
+"""
 
 _DEG_AXIS = "ROTARY_TEST:axis1"
 _MDEG_AXIS = "ROTARY_TEST:axis2"
 _RAD_AXIS = "ROTARY_TEST:axis3"
 _ARCSEC_AXIS = "ROTARY_TEST:axis4"
 
-# The same physical angle (0.5 deg) expressed in each axis's EGU
 _HALF_DEGREE_CASES = [
     (_DEG_AXIS, 1, 0.5),
     (_MDEG_AXIS, 2, 500.0),
     (_RAD_AXIS, 3, 0.5 * math.pi / 180.0),
     (_ARCSEC_AXIS, 4, 1800.0),
 ]
+"""The same physical angle (0.5°) expressed in each axis's EGU."""
 
 @pytest.mark.parametrize(("pv", "axis", "value"), _HALF_DEGREE_CASES)
 async def test_rotary_egu_reaches_half_degree(

--- a/tests/e2e/test_rotary_units.py
+++ b/tests/e2e/test_rotary_units.py
@@ -1,27 +1,12 @@
-"""E2e tests for rotary units / MRES interpretation.
+"""E2e tests for rotary units / MRES interpretation."""
 
-Runs against the XMCC_ROTARY controller (mock X-MCC4 with four rotary axes), created with
-unitsPerStep "1e-6 1e-6 1e-6 1e-6" so every axis has a 1 micro-degree step. Each
-axis displays a different angular EGU via its MRES:
-
-  axis1  EGU=deg,    MRES=1e-6
-  axis2  EGU=mdeg,   MRES=1e-3
-  axis3  EGU=rad,    MRES=pi/180 * 1e-6
-  axis4  EGU=arcsec, MRES=3.6e-3
-
-All four drive the same physical rotary stage, so a given real-world angle maps to
-the same native microstep count regardless of the EGU the record displays.
-"""
-
-import asyncio
-import contextlib
 import math
-from collections.abc import AsyncIterator
 
 import pytest
 from zaber_ascii_mock import MockDevice
 
 from tests.e2e.ca_helpers import get_float, put
+from tests.e2e.mock_helpers import completing_moves, move
 
 pytestmark = pytest.mark.usefixtures("ioc_process", "reset_rotary_state")
 
@@ -33,32 +18,6 @@ _DEG_AXIS = "ROTARY_TEST:axis1"
 _MDEG_AXIS = "ROTARY_TEST:axis2"
 _RAD_AXIS = "ROTARY_TEST:axis3"
 _ARCSEC_AXIS = "ROTARY_TEST:axis4"
-
-
-@contextlib.asynccontextmanager
-async def _completing_moves(mock: MockDevice) -> AsyncIterator[None]:
-    """Complete in-progress mock moves so blocking motions finish."""
-    stop = asyncio.Event()
-
-    async def run() -> None:
-        while not stop.is_set():
-            for ax in mock._axes.values():  # noqa: SLF001
-                if ax.is_busy:
-                    ax.complete_move()
-            await asyncio.sleep(0.02)
-
-    task = asyncio.create_task(run())
-    try:
-        yield
-    finally:
-        stop.set()
-        await task
-
-
-async def _move(pv: str, value: float, mock: MockDevice) -> None:
-    """Command an absolute move and block until it completes."""
-    async with _completing_moves(mock):
-        await put(f"{pv}.VAL", value, wait=True, timeout=20)
 
 # The same physical angle (0.5 deg) expressed in each axis's EGU
 _HALF_DEGREE_CASES = [
@@ -73,7 +32,7 @@ async def test_rotary_egu_reaches_half_degree(
     rotary_mock_device: MockDevice, pv: str, axis: int, value: float
 ) -> None:
     """Each EGU commands and reads back correctly for the same 0.5 deg move."""
-    await _move(pv, value, rotary_mock_device)
+    await move(pv, value, rotary_mock_device)
 
     assert rotary_mock_device.axis(axis).position == round(0.5 * MICROSTEPS_PER_DEG)
     assert abs(await get_float(f"{pv}.RBV") - value) < 1e-12
@@ -81,7 +40,7 @@ async def test_rotary_egu_reaches_half_degree(
 
 async def test_rotary_sub_degree_move_resolves(rotary_mock_device: MockDevice) -> None:
     """A sub-degree move resolves."""
-    await _move(_DEG_AXIS, 0.005, rotary_mock_device)
+    await move(_DEG_AXIS, 0.005, rotary_mock_device)
 
     assert rotary_mock_device.axis(1).position == round(0.005 * MICROSTEPS_PER_DEG)
     assert abs(await get_float(f"{_DEG_AXIS}.RBV") - 0.005) < 1e-6
@@ -89,7 +48,7 @@ async def test_rotary_sub_degree_move_resolves(rotary_mock_device: MockDevice) -
 
 async def test_rotary_axes_independent_egus(rotary_mock_device: MockDevice) -> None:
     """Different-EGU axes on one controller move to distinct physical angles concurrently."""
-    async with _completing_moves(rotary_mock_device):
+    async with completing_moves(rotary_mock_device):
         await put(f"{_DEG_AXIS}.VAL", 1.0, wait=True, timeout=20)  # 1 deg
         await put(f"{_ARCSEC_AXIS}.VAL", 1800.0, wait=True, timeout=20)  # 0.5 deg
 

--- a/tests/e2e/test_rotary_units.py
+++ b/tests/e2e/test_rotary_units.py
@@ -1,0 +1,99 @@
+"""E2e tests for rotary units / MRES interpretation.
+
+Runs against the XMCC_ROTARY controller (mock X-MCC4 with four rotary axes), created with
+unitsPerStep "1e-6 1e-6 1e-6 1e-6" so every axis has a 1 micro-degree step. Each
+axis displays a different angular EGU via its MRES:
+
+  axis1  EGU=deg,    MRES=1e-6
+  axis2  EGU=mdeg,   MRES=1e-3
+  axis3  EGU=rad,    MRES=pi/180 * 1e-6
+  axis4  EGU=arcsec, MRES=3.6e-3
+
+All four drive the same physical rotary stage, so a given real-world angle maps to
+the same native microstep count regardless of the EGU the record displays.
+"""
+
+import asyncio
+import contextlib
+import math
+from collections.abc import AsyncIterator
+
+import pytest
+from zaber_ascii_mock import MockDevice
+
+from tests.e2e.ca_helpers import get_float, put
+
+pytestmark = pytest.mark.usefixtures("ioc_process", "reset_rotary_state")
+
+# Native microsteps per degree for the mock's rotary peripheral (46657): a 0.5 deg
+# move lands at 3200 microsteps, i.e. 6400 microsteps/deg.
+MICROSTEPS_PER_DEG = 6400
+
+_DEG_AXIS = "ROTARY_TEST:axis1"
+_MDEG_AXIS = "ROTARY_TEST:axis2"
+_RAD_AXIS = "ROTARY_TEST:axis3"
+_ARCSEC_AXIS = "ROTARY_TEST:axis4"
+
+
+@contextlib.asynccontextmanager
+async def _completing_moves(mock: MockDevice) -> AsyncIterator[None]:
+    """Complete in-progress mock moves so blocking motions finish."""
+    stop = asyncio.Event()
+
+    async def run() -> None:
+        while not stop.is_set():
+            for ax in mock._axes.values():  # noqa: SLF001
+                if ax.is_busy:
+                    ax.complete_move()
+            await asyncio.sleep(0.02)
+
+    task = asyncio.create_task(run())
+    try:
+        yield
+    finally:
+        stop.set()
+        await task
+
+
+async def _move(pv: str, value: float, mock: MockDevice) -> None:
+    """Command an absolute move and block until it completes."""
+    async with _completing_moves(mock):
+        await put(f"{pv}.VAL", value, wait=True, timeout=20)
+
+# The same physical angle (0.5 deg) expressed in each axis's EGU
+_HALF_DEGREE_CASES = [
+    (_DEG_AXIS, 1, 0.5),
+    (_MDEG_AXIS, 2, 500.0),
+    (_RAD_AXIS, 3, 0.5 * math.pi / 180.0),
+    (_ARCSEC_AXIS, 4, 1800.0),
+]
+
+@pytest.mark.parametrize(("pv", "axis", "value"), _HALF_DEGREE_CASES)
+async def test_rotary_egu_reaches_half_degree(
+    rotary_mock_device: MockDevice, pv: str, axis: int, value: float
+) -> None:
+    """Each EGU commands and reads back correctly for the same 0.5 deg move."""
+    await _move(pv, value, rotary_mock_device)
+
+    assert rotary_mock_device.axis(axis).position == round(0.5 * MICROSTEPS_PER_DEG)
+    assert abs(await get_float(f"{pv}.RBV") - value) < 1e-12
+
+
+async def test_rotary_sub_degree_move_resolves(rotary_mock_device: MockDevice) -> None:
+    """A sub-degree move resolves."""
+    await _move(_DEG_AXIS, 0.005, rotary_mock_device)
+
+    assert rotary_mock_device.axis(1).position == round(0.005 * MICROSTEPS_PER_DEG)
+    assert abs(await get_float(f"{_DEG_AXIS}.RBV") - 0.005) < 1e-6
+
+
+async def test_rotary_axes_independent_egus(rotary_mock_device: MockDevice) -> None:
+    """Different-EGU axes on one controller move to distinct physical angles concurrently."""
+    async with _completing_moves(rotary_mock_device):
+        await put(f"{_DEG_AXIS}.VAL", 1.0, wait=True, timeout=20)  # 1 deg
+        await put(f"{_ARCSEC_AXIS}.VAL", 1800.0, wait=True, timeout=20)  # 0.5 deg
+
+    assert rotary_mock_device.axis(1).position == round(1.0 * MICROSTEPS_PER_DEG)
+    assert rotary_mock_device.axis(4).position == round(0.5 * MICROSTEPS_PER_DEG)
+    assert abs(await get_float(f"{_DEG_AXIS}.RBV") - 1.0) < 1e-6
+    assert abs(await get_float(f"{_ARCSEC_AXIS}.RBV") - 1800.0) < 1e-3

--- a/uv.lock
+++ b/uv.lock
@@ -73,7 +73,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff", specifier = "~=0.14.0" },
-    { name = "zaber-ascii-mock", specifier = "~=0.1.2", index = "https://gitlab.izaber.com/api/v4/projects/1245/packages/pypi/simple" },
+    { name = "zaber-ascii-mock", specifier = "~=0.2.0", index = "https://gitlab.izaber.com/api/v4/projects/1245/packages/pypi/simple" },
 ]
 
 [[package]]
@@ -231,9 +231,9 @@ wheels = [
 
 [[package]]
 name = "zaber-ascii-mock"
-version = "0.1.2"
+version = "0.2.0"
 source = { registry = "https://gitlab.izaber.com/api/v4/projects/1245/packages/pypi/simple" }
-sdist = { url = "https://gitlab.izaber.com/api/v4/projects/1245/packages/pypi/files/d1475dd14096369d57a451a53d1752d6939ccb1b1ba5c865d9640daee739e3c3/zaber_ascii_mock-0.1.2.tar.gz", hash = "sha256:d1475dd14096369d57a451a53d1752d6939ccb1b1ba5c865d9640daee739e3c3" }
+sdist = { url = "https://gitlab.izaber.com/api/v4/projects/1245/packages/pypi/files/146c1f23ac9e6a0b3197198be65ac97dfca6daf5994dfa1197624280fc32ecbf/zaber_ascii_mock-0.2.0.tar.gz", hash = "sha256:146c1f23ac9e6a0b3197198be65ac97dfca6daf5994dfa1197624280fc32ecbf" }
 wheels = [
-    { url = "https://gitlab.izaber.com/api/v4/projects/1245/packages/pypi/files/b57a4e041e4cc677b1649057ca2b50503a82744bc0d50ec243df75af88c031d9/zaber_ascii_mock-0.1.2-py3-none-any.whl", hash = "sha256:b57a4e041e4cc677b1649057ca2b50503a82744bc0d50ec243df75af88c031d9" },
+    { url = "https://gitlab.izaber.com/api/v4/projects/1245/packages/pypi/files/60fa318259695fa47d6aad68ef6cedaa845612175852e11d9ab60943c7ecedc3/zaber_ascii_mock-0.2.0-py3-none-any.whl", hash = "sha256:60fa318259695fa47d6aad68ef6cedaa845612175852e11d9ab60943c7ecedc3" },
 ]

--- a/zaberMotionApp/src/zaberAxis.cpp
+++ b/zaberMotionApp/src/zaberAxis.cpp
@@ -35,11 +35,11 @@ const std::unordered_map<std::string, std::string> zaberAxis::ZML_FAULT_TO_MESSA
     {zml::ascii::warning_flags::EXCESSIVE_TWIST, "Excessive twist"},
 };
 
-zaberAxis::zaberAxis(zaberController *pC, int axisNo, double unitsPerStep) :
+zaberAxis::zaberAxis(zaberController *pC, int axisNo, double stepScaleFactor) :
         asynMotorAxis(pC, axisNo) {
     pC_ = pC;
     axis_ = pC->getDeviceAxis(axisNo);
-    unitsPerStep_ = unitsPerStep;
+    stepScaleFactor_ = stepScaleFactor;
     std::function<asynStatus()> action = [this]() {
         asynStatus status = asynSuccess;
         switch (axis_.getAxisType()) {
@@ -121,11 +121,10 @@ asynStatus zaberAxis::moveVelocity(double minVelocity, double maxVelocity, doubl
     (void)minVelocity;
 
     std::function<asynStatus()> action = [this, maxVelocity, acceleration]() {
-        double scale = unitsPerStep_;
         zml::ascii::Axis::MoveVelocityOptions options{
-            .acceleration = acceleration * scale,
+            .acceleration = acceleration * stepScaleFactor_,
             .accelerationUnit = accelUnit_};
-        axis_.moveVelocity(maxVelocity * scale, velocityUnit_, options);
+        axis_.moveVelocity(maxVelocity * stepScaleFactor_, velocityUnit_, options);
         return asynSuccess;
     };
     asynStatus status = zaber::epics::handleException(pC_->pasynUserSelf, action);
@@ -162,9 +161,8 @@ asynStatus zaberAxis::home(double minVelocity, double maxVelocity, double accele
  */
 asynStatus zaberAxis::stop(double acceleration) {
     std::function<asynStatus()> action = [this, acceleration]() {
-        double scale = unitsPerStep_;
         zml::ascii::Axis::MoveVelocityOptions options{
-            .acceleration = acceleration * scale,
+            .acceleration = acceleration * stepScaleFactor_,
             .accelerationUnit = accelUnit_};
         axis_.moveVelocity(0., velocityUnit_, options);
         return asynSuccess;
@@ -184,7 +182,7 @@ asynStatus zaberAxis::poll(bool *moving) {
         setIntegerParam(pC_->motorStatusMoving_, static_cast<int>(*moving));
         setIntegerParam(pC_->motorStatusHomed_, static_cast<int>(axis_.isHomed()));
 
-        double pos = axis_.getPosition(positionUnit_) / unitsPerStep_;
+        double pos = axis_.getPosition(positionUnit_) / stepScaleFactor_;
         setDoubleParam(pC_->motorPosition_, pos);
         setIntegerParam(pC_->motorStatusCommsError_, 0);
 
@@ -222,8 +220,7 @@ asynStatus zaberAxis::poll(bool *moving) {
  */
 asynStatus zaberAxis::setPosition(double position) {
     std::function<asynStatus()> action = [this, position]() {
-        double scale = unitsPerStep_;
-        axis_.getSettings().set("pos", position * scale, positionUnit_);
+        axis_.getSettings().set("pos", position * stepScaleFactor_, positionUnit_);
         return asynSuccess;
     };
     return zaber::epics::handleException(pC_->pasynUserSelf, action);
@@ -234,14 +231,13 @@ asynStatus zaberAxis::setPosition(double position) {
 
 asynStatus zaberAxis::doAbsoluteMove(double position, double velocity, double acceleration) {
     std::function<asynStatus()> action = [this, position, velocity, acceleration]() {
-        double scale = unitsPerStep_;
         zml::ascii::Axis::MoveAbsoluteOptions options{
             .waitUntilIdle = false,
-            .velocity = velocity * scale,
+            .velocity = velocity * stepScaleFactor_,
             .velocityUnit = velocityUnit_,
-            .acceleration = acceleration * scale,
+            .acceleration = acceleration * stepScaleFactor_,
             .accelerationUnit = accelUnit_};
-        axis_.moveAbsolute(position * scale, positionUnit_, options);
+        axis_.moveAbsolute(position * stepScaleFactor_, positionUnit_, options);
         return asynSuccess;
     };
     return zaber::epics::handleException(pC_->pasynUserSelf, action);
@@ -249,14 +245,13 @@ asynStatus zaberAxis::doAbsoluteMove(double position, double velocity, double ac
 
 asynStatus zaberAxis::doRelativeMove(double distance, double velocity, double acceleration) {
     std::function<asynStatus()> action = [this, distance, velocity, acceleration]() {
-        double scale = unitsPerStep_;
         zml::ascii::Axis::MoveRelativeOptions options{
             .waitUntilIdle = false,
-            .velocity = velocity * scale,
+            .velocity = velocity * stepScaleFactor_,
             .velocityUnit = velocityUnit_,
-            .acceleration = acceleration * scale,
+            .acceleration = acceleration * stepScaleFactor_,
             .accelerationUnit = accelUnit_};
-        axis_.moveRelative(distance * scale, positionUnit_, options);
+        axis_.moveRelative(distance * stepScaleFactor_, positionUnit_, options);
         return asynSuccess;
     };
     return zaber::epics::handleException(pC_->pasynUserSelf, action);

--- a/zaberMotionApp/src/zaberAxis.cpp
+++ b/zaberMotionApp/src/zaberAxis.cpp
@@ -35,17 +35,18 @@ const std::unordered_map<std::string, std::string> zaberAxis::ZML_FAULT_TO_MESSA
     {zml::ascii::warning_flags::EXCESSIVE_TWIST, "Excessive twist"},
 };
 
-zaberAxis::zaberAxis(zaberController *pC, int axisNo) :
+zaberAxis::zaberAxis(zaberController *pC, int axisNo, double unitsPerStep) :
         asynMotorAxis(pC, axisNo) {
     pC_ = pC;
     axis_ = pC->getDeviceAxis(axisNo);
+    unitsPerStep_ = unitsPerStep;
     std::function<asynStatus()> action = [this]() {
         asynStatus status = asynSuccess;
         switch (axis_.getAxisType()) {
             case zml::ascii::AxisType::LINEAR:
-                positionUnit_ = zml::Units::LENGTH_MILLIMETRES;
-                velocityUnit_ = zml::Units::VELOCITY_MILLIMETRES_PER_SECOND;
-                accelUnit_ = zml::Units::ACCELERATION_MILLIMETRES_PER_SECOND_SQUARED;
+                positionUnit_ = zml::Units::LENGTH_MICROMETRES;
+                velocityUnit_ = zml::Units::VELOCITY_MICROMETRES_PER_SECOND;
+                accelUnit_ = zml::Units::ACCELERATION_MICROMETRES_PER_SECOND_SQUARED;
                 break;
             case zml::ascii::AxisType::ROTARY:
                 positionUnit_ = zml::Units::ANGLE_DEGREES;
@@ -120,7 +121,7 @@ asynStatus zaberAxis::moveVelocity(double minVelocity, double maxVelocity, doubl
     (void)minVelocity;
 
     std::function<asynStatus()> action = [this, maxVelocity, acceleration]() {
-        double scale = getStepScale(/*warnIfUnset=*/true);
+        double scale = unitsPerStep_;
         zml::ascii::Axis::MoveVelocityOptions options{
             .acceleration = acceleration * scale,
             .accelerationUnit = accelUnit_};
@@ -161,7 +162,7 @@ asynStatus zaberAxis::home(double minVelocity, double maxVelocity, double accele
  */
 asynStatus zaberAxis::stop(double acceleration) {
     std::function<asynStatus()> action = [this, acceleration]() {
-        double scale = getStepScale(/*warnIfUnset=*/true);
+        double scale = unitsPerStep_;
         zml::ascii::Axis::MoveVelocityOptions options{
             .acceleration = acceleration * scale,
             .accelerationUnit = accelUnit_};
@@ -183,7 +184,7 @@ asynStatus zaberAxis::poll(bool *moving) {
         setIntegerParam(pC_->motorStatusMoving_, static_cast<int>(*moving));
         setIntegerParam(pC_->motorStatusHomed_, static_cast<int>(axis_.isHomed()));
 
-        double pos = axis_.getPosition(positionUnit_) / getStepScale();
+        double pos = axis_.getPosition(positionUnit_) / unitsPerStep_;
         setDoubleParam(pC_->motorPosition_, pos);
         setIntegerParam(pC_->motorStatusCommsError_, 0);
 
@@ -221,7 +222,7 @@ asynStatus zaberAxis::poll(bool *moving) {
  */
 asynStatus zaberAxis::setPosition(double position) {
     std::function<asynStatus()> action = [this, position]() {
-        double scale = getStepScale(/*warnIfUnset=*/true);
+        double scale = unitsPerStep_;
         axis_.getSettings().set("pos", position * scale, positionUnit_);
         return asynSuccess;
     };
@@ -231,29 +232,9 @@ asynStatus zaberAxis::setPosition(double position) {
 /* Private member functions */
 
 
-/**
- * Get physical units (positionUnit_) per motor-record step.
- *
- * @param warnIfUnset Log a warning message if resolution has not yet been set for this axis.
- */
-double zaberAxis::getStepScale(bool warnIfUnset) const {
-    double mres = 0.0;
-    pC_->getDoubleParam(axisNo_, pC_->motorRecResolution_, &mres);
-    if (mres != 0.0) {
-        return mres;
-    }
-    if (warnIfUnset) {
-        asynPrint(pC_->pasynUserSelf, ASYN_TRACE_ERROR,
-            "zaberAxis::getStepScale: axis %d MRES record has no value (MOTOR_REC_RESOLUTION is 0). "
-            "Defaulting to unit scale of 1.0. Ensure the record's resolution ao is set.\n",
-            axisNo_);
-    }
-    return 1.0;
-}
-
 asynStatus zaberAxis::doAbsoluteMove(double position, double velocity, double acceleration) {
     std::function<asynStatus()> action = [this, position, velocity, acceleration]() {
-        double scale = getStepScale(/*warnIfUnset=*/true);
+        double scale = unitsPerStep_;
         zml::ascii::Axis::MoveAbsoluteOptions options{
             .waitUntilIdle = false,
             .velocity = velocity * scale,
@@ -268,7 +249,7 @@ asynStatus zaberAxis::doAbsoluteMove(double position, double velocity, double ac
 
 asynStatus zaberAxis::doRelativeMove(double distance, double velocity, double acceleration) {
     std::function<asynStatus()> action = [this, distance, velocity, acceleration]() {
-        double scale = getStepScale(/*warnIfUnset=*/true);
+        double scale = unitsPerStep_;
         zml::ascii::Axis::MoveRelativeOptions options{
             .waitUntilIdle = false,
             .velocity = velocity * scale,

--- a/zaberMotionApp/src/zaberAxis.h
+++ b/zaberMotionApp/src/zaberAxis.h
@@ -32,6 +32,8 @@ class epicsShareClass zaberAxis : public asynMotorAxis {
     zml::Units positionUnit_;
     zml::Units velocityUnit_;
     zml::Units accelUnit_;
+    // Size of one motor-record step in positionUnit_ (um/deg) -- the same step the
+    // record's MRES describes in EGU. Defaults to 1.0 (1 um or 1 deg per step).
     double unitsPerStep_ = 1.0;
 
     asynStatus doAbsoluteMove(double position, double velocity, double acceleration);

--- a/zaberMotionApp/src/zaberAxis.h
+++ b/zaberMotionApp/src/zaberAxis.h
@@ -15,7 +15,7 @@ class zaberController;
 
 class epicsShareClass zaberAxis : public asynMotorAxis {
     public:
-    zaberAxis(zaberController *pC, int axisNo);
+    zaberAxis(zaberController *pC, int axisNo, double unitsPerStep);
     ~zaberAxis();
     void report(FILE *fp, int details) override;
     asynStatus move(double position, int relative, double minVelocity, double maxVelocity, double acceleration) override;
@@ -32,11 +32,11 @@ class epicsShareClass zaberAxis : public asynMotorAxis {
     zml::Units positionUnit_;
     zml::Units velocityUnit_;
     zml::Units accelUnit_;
+    double unitsPerStep_ = 1.0;
 
     asynStatus doAbsoluteMove(double position, double velocity, double acceleration);
     asynStatus doRelativeMove(double distance, double velocity, double acceleration);
 
-    double getStepScale(bool warnIfUnset = false) const;
     inline bool checkAllFlags(const std::unordered_set<std::string> &flags);
 
     friend class zaberController;

--- a/zaberMotionApp/src/zaberAxis.h
+++ b/zaberMotionApp/src/zaberAxis.h
@@ -15,7 +15,7 @@ class zaberController;
 
 class epicsShareClass zaberAxis : public asynMotorAxis {
     public:
-    zaberAxis(zaberController *pC, int axisNo, double unitsPerStep);
+    zaberAxis(zaberController *pC, int axisNo, double stepScaleFactor);
     ~zaberAxis();
     void report(FILE *fp, int details) override;
     asynStatus move(double position, int relative, double minVelocity, double maxVelocity, double acceleration) override;
@@ -32,9 +32,7 @@ class epicsShareClass zaberAxis : public asynMotorAxis {
     zml::Units positionUnit_;
     zml::Units velocityUnit_;
     zml::Units accelUnit_;
-    // Size of one motor-record step in positionUnit_ (um/deg) -- the same step the
-    // record's MRES describes in EGU. Defaults to 1.0 (1 um or 1 deg per step).
-    double unitsPerStep_ = 1.0;
+    double stepScaleFactor_ = 1.0;
 
     asynStatus doAbsoluteMove(double position, double velocity, double acceleration);
     asynStatus doRelativeMove(double distance, double velocity, double acceleration);

--- a/zaberMotionApp/src/zaberController.cpp
+++ b/zaberMotionApp/src/zaberController.cpp
@@ -45,10 +45,10 @@ static void zaberProfileThreadC(void *pPvt) {
  * \param[in] idlePollPeriod    The time between polls when no axis is moving
  * \param[in] devicePort        The tcp or serial port that the zaber device is connected to
  * \param[in] deviceNumber      The number of the device on the port (1-indexed)
- * \param[in] unitsPerStep      The per-axis step size, expressed as a fraction of the driver's default motion units
+ * \param[in] stepScaleFactor      The per-axis step size, expressed as a fraction of the driver's default motion units
  *                              (microns for linear devices and degrees for rotary).
  */
-zaberController::zaberController(const char *portName, int numAxes, double movingPollPeriod, double idlePollPeriod, const char *devicePort, int deviceNumber, const std::vector<double> &unitsPerStep) :
+zaberController::zaberController(const char *portName, int numAxes, double movingPollPeriod, double idlePollPeriod, const char *devicePort, int deviceNumber, const std::vector<double> &stepScaleFactor) :
         asynMotorController(portName, numAxes, 1, 0, 0, ASYN_CANBLOCK | ASYN_MULTIDEVICE, 1 /* autoconnect */, 0, 0) {
     createParam(ZaberPulseWidthMsString, asynParamFloat64, &zaberPulseWidthMs_);
     try {
@@ -59,11 +59,11 @@ zaberController::zaberController(const char *portName, int numAxes, double movin
         fprintf(stderr, "zaberController: Initialization failed\n\t%s\n", e.what());
     }
     for(int i = 0; i < numAxes; i++) {
-        double axisUnitsPerStep = 1.0;
-        if (i < static_cast<int>(unitsPerStep.size())) {
-            axisUnitsPerStep = unitsPerStep[i];
+        double axisStepScaleFactor = 1.0;
+        if (i < static_cast<int>(stepScaleFactor.size())) {
+            axisStepScaleFactor = stepScaleFactor[i];
         }
-        new zaberAxis(this, i, axisUnitsPerStep);
+        new zaberAxis(this, i, axisStepScaleFactor);
     }
     startPoller(movingPollPeriod / 1000.0, idlePollPeriod / 1000.0, 2);
 
@@ -168,7 +168,7 @@ asynStatus zaberController::buildProfile() {
             std::vector<std::optional<zml::Measurement>> positions;
             for (int axisNum : usedAxes) {
                 const zaberAxis *axis = getAxis(axisNum - 1);
-                positions.push_back(zml::Measurement{axis->profilePositions_[i] * axis->unitsPerStep_, axis->positionUnit_});
+                positions.push_back(zml::Measurement{axis->profilePositions_[i] * axis->stepScaleFactor_, axis->positionUnit_});
             }
             // Point 0 is the starting position.
             // This driver will move the device to this starting position when the profile is executed.
@@ -256,7 +256,7 @@ void zaberController::runProfile() {
             for (int axisNum : usedAxes) {
                 // Move to start position using device's current velocity/acceleration settings.
                 zaberAxis *axis = getAxis(axisNum - 1);
-                axis->axis_.moveAbsolute(axis->profilePositions_[0] * axis->unitsPerStep_, axis->positionUnit_, /*waitUntilIdle=*/true);
+                axis->axis_.moveAbsolute(axis->profilePositions_[0] * axis->stepScaleFactor_, axis->positionUnit_, /*waitUntilIdle=*/true);
             }
         }
 
@@ -332,7 +332,7 @@ asynStatus zaberController::readbackProfile() {
                 throw std::runtime_error("Attempted to access invalid axis at index: " + std::to_string(i));
             }
 
-            const double scale = axis->unitsPerStep_;
+            const double scale = axis->stepScaleFactor_;
             std::vector<double> positions;
             positions.reserve(numPulses);
             for (int pointIndex = startPulses - 1; pointIndex <= endPulses - 1; pointIndex++) {

--- a/zaberMotionApp/src/zaberController.cpp
+++ b/zaberMotionApp/src/zaberController.cpp
@@ -45,8 +45,8 @@ static void zaberProfileThreadC(void *pPvt) {
  * \param[in] idlePollPeriod    The time between polls when no axis is moving
  * \param[in] devicePort        The tcp or serial port that the zaber device is connected to
  * \param[in] deviceNumber      The number of the device on the port (1-indexed)
- * \param[in] stepScaleFactor      The per-axis step size, expressed as a fraction of the driver's default motion units
- *                              (microns for linear devices and degrees for rotary).
+ * \param[in] stepScaleFactor   The per-axis step size, expressed as a fraction of the driver's default motion units
+ *                              (um for linear devices and degrees for rotary).
  */
 zaberController::zaberController(const char *portName, int numAxes, double movingPollPeriod, double idlePollPeriod, const char *devicePort, int deviceNumber, const std::vector<double> &stepScaleFactor) :
         asynMotorController(portName, numAxes, 1, 0, 0, ASYN_CANBLOCK | ASYN_MULTIDEVICE, 1 /* autoconnect */, 0, 0) {

--- a/zaberMotionApp/src/zaberController.cpp
+++ b/zaberMotionApp/src/zaberController.cpp
@@ -46,7 +46,7 @@ static void zaberProfileThreadC(void *pPvt) {
  * \param[in] devicePort        The tcp or serial port that the zaber device is connected to
  * \param[in] deviceNumber      The number of the device on the port (1-indexed)
  */
-zaberController::zaberController(const char *portName, int numAxes, double movingPollPeriod, double idlePollPeriod, const char *devicePort, int deviceNumber) :
+zaberController::zaberController(const char *portName, int numAxes, double movingPollPeriod, double idlePollPeriod, const char *devicePort, int deviceNumber, const std::vector<double> &unitsPerStep) :
         asynMotorController(portName, numAxes, 1, 0, 0, ASYN_CANBLOCK | ASYN_MULTIDEVICE, 1 /* autoconnect */, 0, 0) {
     createParam(ZaberPulseWidthMsString, asynParamFloat64, &zaberPulseWidthMs_);
     try {
@@ -57,7 +57,11 @@ zaberController::zaberController(const char *portName, int numAxes, double movin
         fprintf(stderr, "zaberController: Initialization failed\n\t%s\n", e.what());
     }
     for(int i = 0; i < numAxes; i++) {
-        new zaberAxis(this, i);
+        double axisUnitsPerStep = 1.0;
+        if (i < static_cast<int>(unitsPerStep.size())) {
+            axisUnitsPerStep = unitsPerStep[i];
+        }
+        new zaberAxis(this, i, axisUnitsPerStep);
     }
     startPoller(movingPollPeriod / 1000.0, idlePollPeriod / 1000.0, 2);
 
@@ -162,7 +166,7 @@ asynStatus zaberController::buildProfile() {
             std::vector<std::optional<zml::Measurement>> positions;
             for (int axisNum : usedAxes) {
                 const zaberAxis *axis = getAxis(axisNum - 1);
-                positions.push_back(zml::Measurement{axis->profilePositions_[i] * axis->getStepScale(), axis->positionUnit_});
+                positions.push_back(zml::Measurement{axis->profilePositions_[i] * axis->unitsPerStep_, axis->positionUnit_});
             }
             // Point 0 is the starting position.
             // This driver will move the device to this starting position when the profile is executed.
@@ -250,7 +254,7 @@ void zaberController::runProfile() {
             for (int axisNum : usedAxes) {
                 // Move to start position using device's current velocity/acceleration settings.
                 zaberAxis *axis = getAxis(axisNum - 1);
-                axis->axis_.moveAbsolute(axis->profilePositions_[0] * axis->getStepScale(), axis->positionUnit_, /*waitUntilIdle=*/true);
+                axis->axis_.moveAbsolute(axis->profilePositions_[0] * axis->unitsPerStep_, axis->positionUnit_, /*waitUntilIdle=*/true);
             }
         }
 
@@ -326,7 +330,7 @@ asynStatus zaberController::readbackProfile() {
                 throw std::runtime_error("Attempted to access invalid axis at index: " + std::to_string(i));
             }
 
-            const double scale = axis->getStepScale();
+            const double scale = axis->unitsPerStep_;
             std::vector<double> positions;
             positions.reserve(numPulses);
             for (int pointIndex = startPulses - 1; pointIndex <= endPulses - 1; pointIndex++) {

--- a/zaberMotionApp/src/zaberController.cpp
+++ b/zaberMotionApp/src/zaberController.cpp
@@ -45,6 +45,8 @@ static void zaberProfileThreadC(void *pPvt) {
  * \param[in] idlePollPeriod    The time between polls when no axis is moving
  * \param[in] devicePort        The tcp or serial port that the zaber device is connected to
  * \param[in] deviceNumber      The number of the device on the port (1-indexed)
+ * \param[in] unitsPerStep      The per-axis step size, expressed as a fraction of the driver's default motion units
+ *                              (microns for linear devices and degrees for rotary).
  */
 zaberController::zaberController(const char *portName, int numAxes, double movingPollPeriod, double idlePollPeriod, const char *devicePort, int deviceNumber, const std::vector<double> &unitsPerStep) :
         asynMotorController(portName, numAxes, 1, 0, 0, ASYN_CANBLOCK | ASYN_MULTIDEVICE, 1 /* autoconnect */, 0, 0) {

--- a/zaberMotionApp/src/zaberController.h
+++ b/zaberMotionApp/src/zaberController.h
@@ -19,7 +19,7 @@ namespace zml = zaber::motion;
 
 class epicsShareClass zaberController : public asynMotorController {
     public:
-    zaberController(const char *portName, int numAxes, double movingPollPeriod, double idlePollPeriod, const char *devicePort, int deviceNumber, const std::vector<double> &unitsPerStep);
+    zaberController(const char *portName, int numAxes, double movingPollPeriod, double idlePollPeriod, const char *devicePort, int deviceNumber, const std::vector<double> &stepScaleFactor);
     void report(FILE *fp, int level) override;
 
     zaberAxis *getAxis(asynUser *pasynUser) override;

--- a/zaberMotionApp/src/zaberController.h
+++ b/zaberMotionApp/src/zaberController.h
@@ -2,6 +2,7 @@
 #define ZABER_BASE_CONTROLLER_H
 
 #include <memory>
+#include <vector>
 
 #include "zaberAxis.h"
 #include <asynMotorController.h>
@@ -18,7 +19,7 @@ namespace zml = zaber::motion;
 
 class epicsShareClass zaberController : public asynMotorController {
     public:
-    zaberController(const char *portName, int numAxes, double movingPollPeriod, double idlePollPeriod, const char *devicePort, int deviceNumber);
+    zaberController(const char *portName, int numAxes, double movingPollPeriod, double idlePollPeriod, const char *devicePort, int deviceNumber, const std::vector<double> &unitsPerStep);
     void report(FILE *fp, int level) override;
 
     zaberAxis *getAxis(asynUser *pasynUser) override;

--- a/zaberMotionApp/src/zaberMotionRegister.cpp
+++ b/zaberMotionApp/src/zaberMotionRegister.cpp
@@ -33,7 +33,7 @@ static const iocshArg zaberMotionConfigArg2 = {"moving poll rate", iocshArgInt};
 static const iocshArg zaberMotionConfigArg3 = {"idle poll rate", iocshArgInt};
 static const iocshArg zaberMotionConfigArg4 = {"zaber serial/tcp port", iocshArgString};
 static const iocshArg zaberMotionConfigArg5 = {"zaber device number", iocshArgInt};
-static const iocshArg zaberMotionConfigArg6 = {"per-axis units-per-step (um linear / deg rotary), optional", iocshArgArgv};
+static const iocshArg zaberMotionConfigArg6 = {"optional per-axis units-per-step (um for linear devices, deg for rotary)", iocshArgArgv};
 
 static const iocshArg *const zaberMotionConfigArgs[7] = {&zaberMotionConfigArg0, &zaberMotionConfigArg1,
     &zaberMotionConfigArg2, &zaberMotionConfigArg3, &zaberMotionConfigArg4, &zaberMotionConfigArg5,

--- a/zaberMotionApp/src/zaberMotionRegister.cpp
+++ b/zaberMotionApp/src/zaberMotionRegister.cpp
@@ -19,7 +19,7 @@ int zaberMotionCreateController(
         int idlePollPeriod,                     /* Time to poll (msec) when an axis is idle. 0 for no polling */
         const char *zaberPort,                  /* Zaber Device TCP address or serial port name (prefixed with tcp:// or serial://) */
         int zaberDeviceNumber,                  /* Zaber Device number on the port (1-indexed) */
-        const std::vector<double> &unitsPerStep /* Per-axis physical units (um linear / deg rotary) per motor-record step; default 1.0 */
+        const std::vector<double> &unitsPerStep /* Per-axis size of one motor step in um (linear) or deg (rotary) -- the step the record MRES describes in EGU; default 1.0 */
 ) {
     zaberController *pController = new zaberController(portName, numAxes, static_cast<double>(movingPollPeriod), static_cast<double>(idlePollPeriod), zaberPort, zaberDeviceNumber, unitsPerStep);
     (void)pController;

--- a/zaberMotionApp/src/zaberMotionRegister.cpp
+++ b/zaberMotionApp/src/zaberMotionRegister.cpp
@@ -4,20 +4,24 @@
 #include <epicsStdio.h>
 #include <iocsh.h>
 
+#include <vector>
+#include <string>
+
 #include "zaberController.h"
 #include "zaber/motion/library.h"
 
 // Zaber Motion Controller
 
 int zaberMotionCreateController(
-        const char *portName,   /* ZaberMotion Motor Asyn Port name */
-        int numAxes,            /* Number of axes this controller supports */
-        int movingPollPeriod,   /* Time to poll (msec) when an axis is in motion */
-        int idlePollPeriod,     /* Time to poll (msec) when an axis is idle. 0 for no polling */
-        const char *zaberPort,  /* Zaber Device TCP address or serial port name (prefixed with tcp:// or serial://) */
-        int zaberDeviceNumber   /* Zaber Device number on the port (1-indexed) */
+        const char *portName,                   /* ZaberMotion Motor Asyn Port name */
+        int numAxes,                            /* Number of axes this controller supports */
+        int movingPollPeriod,                   /* Time to poll (msec) when an axis is in motion */
+        int idlePollPeriod,                     /* Time to poll (msec) when an axis is idle. 0 for no polling */
+        const char *zaberPort,                  /* Zaber Device TCP address or serial port name (prefixed with tcp:// or serial://) */
+        int zaberDeviceNumber,                  /* Zaber Device number on the port (1-indexed) */
+        const std::vector<double> &unitsPerStep /* Per-axis physical units (um linear / deg rotary) per motor-record step; default 1.0 */
 ) {
-    zaberController *pController = new zaberController(portName, numAxes, static_cast<double>(movingPollPeriod), static_cast<double>(idlePollPeriod), zaberPort, zaberDeviceNumber);
+    zaberController *pController = new zaberController(portName, numAxes, static_cast<double>(movingPollPeriod), static_cast<double>(idlePollPeriod), zaberPort, zaberDeviceNumber, unitsPerStep);
     (void)pController;
     return (asynSuccess);
 }
@@ -29,14 +33,26 @@ static const iocshArg zaberMotionConfigArg2 = {"moving poll rate", iocshArgInt};
 static const iocshArg zaberMotionConfigArg3 = {"idle poll rate", iocshArgInt};
 static const iocshArg zaberMotionConfigArg4 = {"zaber serial/tcp port", iocshArgString};
 static const iocshArg zaberMotionConfigArg5 = {"zaber device number", iocshArgInt};
+static const iocshArg zaberMotionConfigArg6 = {"per-axis units-per-step (um linear / deg rotary), optional", iocshArgArgv};
 
-static const iocshArg *const zaberMotionConfigArgs[6] = {&zaberMotionConfigArg0, &zaberMotionConfigArg1,
-    &zaberMotionConfigArg2, &zaberMotionConfigArg3, &zaberMotionConfigArg4, &zaberMotionConfigArg5};
+static const iocshArg *const zaberMotionConfigArgs[7] = {&zaberMotionConfigArg0, &zaberMotionConfigArg1,
+    &zaberMotionConfigArg2, &zaberMotionConfigArg3, &zaberMotionConfigArg4, &zaberMotionConfigArg5,
+    &zaberMotionConfigArg6};
 
-static const iocshFuncDef zaberMotionControllerDef = {"ZaberMotionCreateController", 6, zaberMotionConfigArgs};
+static const iocshFuncDef zaberMotionControllerDef = {"ZaberMotionCreateController", 7, zaberMotionConfigArgs};
 
 static void zaberMotionCreateControllerCallFunc(const iocshArgBuf *args) {
-    zaberMotionCreateController(args[0].sval, args[1].ival, args[2].ival, args[3].ival, args[4].sval, args[5].ival);
+    std::vector<double> unitsPerStep;
+    for (int i = 1; i < args[6].aval.ac; i++) {
+        try {
+            unitsPerStep.push_back(std::stod(args[6].aval.av[i]));
+        } catch (const std::exception &) {
+            printf("ZaberMotionCreateController: could not parse units-per-step '%s' for axis %d; using 1.0\n",
+                   args[6].aval.av[i], i - 1);
+            unitsPerStep.push_back(1.0);
+        }
+    }
+    zaberMotionCreateController(args[0].sval, args[1].ival, args[2].ival, args[3].ival, args[4].sval, args[5].ival, unitsPerStep);
 }
 
 // Create Profile

--- a/zaberMotionApp/src/zaberMotionRegister.cpp
+++ b/zaberMotionApp/src/zaberMotionRegister.cpp
@@ -13,15 +13,15 @@
 // Zaber Motion Controller
 
 int zaberMotionCreateController(
-        const char *portName,                   /* ZaberMotion Motor Asyn Port name */
-        int numAxes,                            /* Number of axes this controller supports */
-        int movingPollPeriod,                   /* Time to poll (msec) when an axis is in motion */
-        int idlePollPeriod,                     /* Time to poll (msec) when an axis is idle. 0 for no polling */
-        const char *zaberPort,                  /* Zaber Device TCP address or serial port name (prefixed with tcp:// or serial://) */
-        int zaberDeviceNumber,                  /* Zaber Device number on the port (1-indexed) */
-        const std::vector<double> &unitsPerStep /* Per-axis size of one motor step in um (linear) or deg (rotary) -- the step the record MRES describes in EGU; default 1.0 */
+        const char *portName,                      /* ZaberMotion Motor Asyn Port name */
+        int numAxes,                               /* Number of axes this controller supports */
+        int movingPollPeriod,                      /* Time to poll (msec) when an axis is in motion */
+        int idlePollPeriod,                        /* Time to poll (msec) when an axis is idle. 0 for no polling */
+        const char *zaberPort,                     /* Zaber Device TCP address or serial port name (prefixed with tcp:// or serial://) */
+        int zaberDeviceNumber,                     /* Zaber Device number on the port (1-indexed) */
+        const std::vector<double> &stepScaleFactor /* Optional per-axis scaling factor applied to default step size: um (linear) or deg (rotary) -- defaults to  1.0 */
 ) {
-    zaberController *pController = new zaberController(portName, numAxes, static_cast<double>(movingPollPeriod), static_cast<double>(idlePollPeriod), zaberPort, zaberDeviceNumber, unitsPerStep);
+    zaberController *pController = new zaberController(portName, numAxes, static_cast<double>(movingPollPeriod), static_cast<double>(idlePollPeriod), zaberPort, zaberDeviceNumber, stepScaleFactor);
     (void)pController;
     return (asynSuccess);
 }
@@ -33,7 +33,7 @@ static const iocshArg zaberMotionConfigArg2 = {"moving poll rate", iocshArgInt};
 static const iocshArg zaberMotionConfigArg3 = {"idle poll rate", iocshArgInt};
 static const iocshArg zaberMotionConfigArg4 = {"zaber serial/tcp port", iocshArgString};
 static const iocshArg zaberMotionConfigArg5 = {"zaber device number", iocshArgInt};
-static const iocshArg zaberMotionConfigArg6 = {"optional per-axis units-per-step (um for linear devices, deg for rotary)", iocshArgArgv};
+static const iocshArg zaberMotionConfigArg6 = {"optional per-axis step scale factor (um for linear devices, deg for rotary)", iocshArgArgv};
 
 static const iocshArg *const zaberMotionConfigArgs[7] = {&zaberMotionConfigArg0, &zaberMotionConfigArg1,
     &zaberMotionConfigArg2, &zaberMotionConfigArg3, &zaberMotionConfigArg4, &zaberMotionConfigArg5,
@@ -42,17 +42,17 @@ static const iocshArg *const zaberMotionConfigArgs[7] = {&zaberMotionConfigArg0,
 static const iocshFuncDef zaberMotionControllerDef = {"ZaberMotionCreateController", 7, zaberMotionConfigArgs};
 
 static void zaberMotionCreateControllerCallFunc(const iocshArgBuf *args) {
-    std::vector<double> unitsPerStep;
+    std::vector<double> stepScaleFactor;
     for (int i = 1; i < args[6].aval.ac; i++) {
         try {
-            unitsPerStep.push_back(std::stod(args[6].aval.av[i]));
+            stepScaleFactor.push_back(std::stod(args[6].aval.av[i]));
         } catch (const std::exception &) {
-            printf("ZaberMotionCreateController: could not parse units-per-step '%s' for axis %d; using 1.0\n",
+            printf("ZaberMotionCreateController: could not parse step scale factor '%s' for axis %d; using 1.0\n",
                    args[6].aval.av[i], i - 1);
-            unitsPerStep.push_back(1.0);
+            stepScaleFactor.push_back(1.0);
         }
     }
-    zaberMotionCreateController(args[0].sval, args[1].ival, args[2].ival, args[3].ival, args[4].sval, args[5].ival, unitsPerStep);
+    zaberMotionCreateController(args[0].sval, args[1].ival, args[2].ival, args[3].ival, args[4].sval, args[5].ival, stepScaleFactor);
 }
 
 // Create Profile


### PR DESCRIPTION
v2.1.0 modified the driver's behaviour so it now reads MRES and uses it to scale Zaber linear / rotary units under the hood. This violated the spec for the relationship between EGU and MRES. This PR proposes a general fix which allows the user to specify an optional per-axis 'scaling factor' for the default linear and rotary units (um and degrees, respectively).

If a user wants micro-degree precision for a rotary axis, they they can pass stepScalingFactor=1e-6, etc..