### PR TITLE
Fix bug introduced by non-standard MRES handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,11 @@ This module provides a single implementation of both `asynMotorController` and `
 
 ### IOC Shell Functions
 
-__ZaberMotionCreateController(port, numAxes, movingPollPeriod, idlePollPeriod, zaberPort, zaberDeviceNum)__
-Instantiates `zaberController` with typical `asynMotorController` params and two zaber device-specific params:
+__ZaberMotionCreateController(port, numAxes, movingPollPeriod, idlePollPeriod, zaberPort, zaberDeviceNum, [stepScaleFactor ...])__
+Instantiates `zaberController` with typical `asynMotorController` params and some zaber device-specific params:
 - `zaberPort`: Address or serial port name of zaber device (prefixed with `tcp://` or `serial://`). A serial port can have multiple devices chained together.
 - `zaberDeviceNum`: Number (1-indexed) of the controller device on a device chain. This number is stable unless the device chain is modified. It can be found using [Zaber Launcher](https://software.zaber.com/zaber-launcher/download).
+- `stepScaleFactor` (optional): Per-axis scaling factors for adjusting the base step size, which is micrometres for linear axes and degrees for rotary axes (e.g. a value of `1e-6` gives a rotary axis micro-degree resolution, `1e-3` gives a linear device nm resolution). Pass one space-separated value per axis, in axis order. Omitted or short entries default to `1.0` (a 1 µm or 1° step size).
 
 __ZaberMotionSetDbPath(path)__
 Allows user to specify the path to a local copy of the [Zaber device database](https://software.zaber.com/motion-library/docs/guides/device_db). This is only necessary if the IOC does not have access to the internet. Download link for current version of device database [here](https://www.zaber.com/software/device-database/devices-public.sqlite.lzma).
@@ -118,7 +119,7 @@ Allows user to specify the path to a local copy of the [Zaber device database](h
 This section is intended to clarify implementation-specific details and limitations for `zaberAxis` and `zaberController`
 
 #### zaberAxis
-Can control either a linear or rotary axis. The units for all motion commands are microns for linear devices and degrees for rotary. Please keep this in mind when configuring motor records.
+Can control either a linear or rotary axis. Motion commands are passed to devices in microns (linear) or degrees (rotary). One motor-record step is `stepScaleFactor` of these units (see `ZaberMotionCreateController` above).
 
 __setPosition(position)__:
 Implemented as specified. Performs unit conversion and calls `set pos <native_units>` as defined [here](https://www.zaber.com/protocol-manual#topic_setting_pos) in Zaber ASCII protocol

--- a/iocs/zaberMotionIOC/iocBoot/iocZaberMotion/motor.cmd.rotary-stage.zaber
+++ b/iocs/zaberMotionIOC/iocBoot/iocZaberMotion/motor.cmd.rotary-stage.zaber
@@ -7,7 +7,8 @@ dbLoadTemplate("motor.substitutions.rotary-stage.zaber")
 #    moving poll period (ms),
 #    idle poll period (ms),
 #    address or serial port name of zaber device (prefixed with tcp:// or serial://),
-#    zaber device number (1-indexed)
+#    zaber device number (1-indexed),
+#    (optional) per-axis step scale factor: um for linear, deg for rotary -- defaults to 1
 # )
 ###
-ZaberMotionCreateController("X-RSW", 1, 100, 5000, "serial:///dev/ttyUSB0", 1)
+ZaberMotionCreateController("X-RSW", 1, 100, 5000, "serial:///dev/ttyUSB0", 1, 1e-6)

--- a/iocs/zaberMotionIOC/iocBoot/iocZaberMotion/motor.substitutions.rotary-stage.zaber
+++ b/iocs/zaberMotionIOC/iocBoot/iocZaberMotion/motor.substitutions.rotary-stage.zaber
@@ -1,8 +1,6 @@
 file "$(MOTOR)/motorApp/Db/asyn_motor.db"
 {
   pattern
-  # MRES sets the readback/command resolution in degrees (the driver scales
-  # ZML moves by MRES). 0.001 => millidegree resolution; lower it for finer.
   {P,             N,          M,        DTYP,    PORT, ADDR,            DESC, EGU, DIR,  VELO, VBAS, ACCL, BDST, BVEL, BACC,  MRES, PREC, DLLM, DHLM, INIT}
-  {ROTARY_STAGE:, 1, "axis$(N)", "asynMotor",   X-RSW,    0, "Rotary Axis 1", deg, Pos,  10.0,  1.0,  0.5,    0,    1,  0.2, 0.001,    4, -360,  360,   ""}
+  {ROTARY_STAGE:, 1, "axis$(N)", "asynMotor",   X-RSW,    0, "Rotary Axis 1", deg, Pos,  10.0,  1.0,  0.5,    0,    1,  0.2, 1e-6,    4, -360,  360,   ""}
 }

--- a/zaberMotionApp/src/zaberAxis.cpp
+++ b/zaberMotionApp/src/zaberAxis.cpp
@@ -35,17 +35,18 @@ const std::unordered_map<std::string, std::string> zaberAxis::ZML_FAULT_TO_MESSA
     {zml::ascii::warning_flags::EXCESSIVE_TWIST, "Excessive twist"},
 };
 
-zaberAxis::zaberAxis(zaberController *pC, int axisNo) :
+zaberAxis::zaberAxis(zaberController *pC, int axisNo, double stepScaleFactor) :
         asynMotorAxis(pC, axisNo) {
     pC_ = pC;
     axis_ = pC->getDeviceAxis(axisNo);
+    stepScaleFactor_ = stepScaleFactor;
     std::function<asynStatus()> action = [this]() {
         asynStatus status = asynSuccess;
         switch (axis_.getAxisType()) {
             case zml::ascii::AxisType::LINEAR:
-                positionUnit_ = zml::Units::LENGTH_MILLIMETRES;
-                velocityUnit_ = zml::Units::VELOCITY_MILLIMETRES_PER_SECOND;
-                accelUnit_ = zml::Units::ACCELERATION_MILLIMETRES_PER_SECOND_SQUARED;
+                positionUnit_ = zml::Units::LENGTH_MICROMETRES;
+                velocityUnit_ = zml::Units::VELOCITY_MICROMETRES_PER_SECOND;
+                accelUnit_ = zml::Units::ACCELERATION_MICROMETRES_PER_SECOND_SQUARED;
                 break;
             case zml::ascii::AxisType::ROTARY:
                 positionUnit_ = zml::Units::ANGLE_DEGREES;
@@ -120,11 +121,10 @@ asynStatus zaberAxis::moveVelocity(double minVelocity, double maxVelocity, doubl
     (void)minVelocity;
 
     std::function<asynStatus()> action = [this, maxVelocity, acceleration]() {
-        double scale = getStepScale(/*warnIfUnset=*/true);
         zml::ascii::Axis::MoveVelocityOptions options{
-            .acceleration = acceleration * scale,
+            .acceleration = acceleration * stepScaleFactor_,
             .accelerationUnit = accelUnit_};
-        axis_.moveVelocity(maxVelocity * scale, velocityUnit_, options);
+        axis_.moveVelocity(maxVelocity * stepScaleFactor_, velocityUnit_, options);
         return asynSuccess;
     };
     asynStatus status = zaber::epics::handleException(pC_->pasynUserSelf, action);
@@ -161,9 +161,8 @@ asynStatus zaberAxis::home(double minVelocity, double maxVelocity, double accele
  */
 asynStatus zaberAxis::stop(double acceleration) {
     std::function<asynStatus()> action = [this, acceleration]() {
-        double scale = getStepScale(/*warnIfUnset=*/true);
         zml::ascii::Axis::MoveVelocityOptions options{
-            .acceleration = acceleration * scale,
+            .acceleration = acceleration * stepScaleFactor_,
             .accelerationUnit = accelUnit_};
         axis_.moveVelocity(0., velocityUnit_, options);
         return asynSuccess;
@@ -183,7 +182,7 @@ asynStatus zaberAxis::poll(bool *moving) {
         setIntegerParam(pC_->motorStatusMoving_, static_cast<int>(*moving));
         setIntegerParam(pC_->motorStatusHomed_, static_cast<int>(axis_.isHomed()));
 
-        double pos = axis_.getPosition(positionUnit_) / getStepScale();
+        double pos = axis_.getPosition(positionUnit_) / stepScaleFactor_;
         setDoubleParam(pC_->motorPosition_, pos);
         setIntegerParam(pC_->motorStatusCommsError_, 0);
 
@@ -221,8 +220,7 @@ asynStatus zaberAxis::poll(bool *moving) {
  */
 asynStatus zaberAxis::setPosition(double position) {
     std::function<asynStatus()> action = [this, position]() {
-        double scale = getStepScale(/*warnIfUnset=*/true);
-        axis_.getSettings().set("pos", position * scale, positionUnit_);
+        axis_.getSettings().set("pos", position * stepScaleFactor_, positionUnit_);
         return asynSuccess;
     };
     return zaber::epics::handleException(pC_->pasynUserSelf, action);
@@ -231,36 +229,15 @@ asynStatus zaberAxis::setPosition(double position) {
 /* Private member functions */
 
 
-/**
- * Get physical units (positionUnit_) per motor-record step.
- *
- * @param warnIfUnset Log a warning message if resolution has not yet been set for this axis.
- */
-double zaberAxis::getStepScale(bool warnIfUnset) const {
-    double mres = 0.0;
-    pC_->getDoubleParam(axisNo_, pC_->motorRecResolution_, &mres);
-    if (mres != 0.0) {
-        return mres;
-    }
-    if (warnIfUnset) {
-        asynPrint(pC_->pasynUserSelf, ASYN_TRACE_ERROR,
-            "zaberAxis::getStepScale: axis %d MRES record has no value (MOTOR_REC_RESOLUTION is 0). "
-            "Defaulting to unit scale of 1.0. Ensure the record's resolution ao is set.\n",
-            axisNo_);
-    }
-    return 1.0;
-}
-
 asynStatus zaberAxis::doAbsoluteMove(double position, double velocity, double acceleration) {
     std::function<asynStatus()> action = [this, position, velocity, acceleration]() {
-        double scale = getStepScale(/*warnIfUnset=*/true);
         zml::ascii::Axis::MoveAbsoluteOptions options{
             .waitUntilIdle = false,
-            .velocity = velocity * scale,
+            .velocity = velocity * stepScaleFactor_,
             .velocityUnit = velocityUnit_,
-            .acceleration = acceleration * scale,
+            .acceleration = acceleration * stepScaleFactor_,
             .accelerationUnit = accelUnit_};
-        axis_.moveAbsolute(position * scale, positionUnit_, options);
+        axis_.moveAbsolute(position * stepScaleFactor_, positionUnit_, options);
         return asynSuccess;
     };
     return zaber::epics::handleException(pC_->pasynUserSelf, action);
@@ -268,14 +245,13 @@ asynStatus zaberAxis::doAbsoluteMove(double position, double velocity, double ac
 
 asynStatus zaberAxis::doRelativeMove(double distance, double velocity, double acceleration) {
     std::function<asynStatus()> action = [this, distance, velocity, acceleration]() {
-        double scale = getStepScale(/*warnIfUnset=*/true);
         zml::ascii::Axis::MoveRelativeOptions options{
             .waitUntilIdle = false,
-            .velocity = velocity * scale,
+            .velocity = velocity * stepScaleFactor_,
             .velocityUnit = velocityUnit_,
-            .acceleration = acceleration * scale,
+            .acceleration = acceleration * stepScaleFactor_,
             .accelerationUnit = accelUnit_};
-        axis_.moveRelative(distance * scale, positionUnit_, options);
+        axis_.moveRelative(distance * stepScaleFactor_, positionUnit_, options);
         return asynSuccess;
     };
     return zaber::epics::handleException(pC_->pasynUserSelf, action);

--- a/zaberMotionApp/src/zaberAxis.h
+++ b/zaberMotionApp/src/zaberAxis.h
@@ -15,7 +15,7 @@ class zaberController;
 
 class epicsShareClass zaberAxis : public asynMotorAxis {
     public:
-    zaberAxis(zaberController *pC, int axisNo);
+    zaberAxis(zaberController *pC, int axisNo, double stepScaleFactor);
     ~zaberAxis();
     void report(FILE *fp, int details) override;
     asynStatus move(double position, int relative, double minVelocity, double maxVelocity, double acceleration) override;
@@ -32,11 +32,11 @@ class epicsShareClass zaberAxis : public asynMotorAxis {
     zml::Units positionUnit_;
     zml::Units velocityUnit_;
     zml::Units accelUnit_;
+    double stepScaleFactor_ = 1.0;
 
     asynStatus doAbsoluteMove(double position, double velocity, double acceleration);
     asynStatus doRelativeMove(double distance, double velocity, double acceleration);
 
-    double getStepScale(bool warnIfUnset = false) const;
     inline bool checkAllFlags(const std::unordered_set<std::string> &flags);
 
     friend class zaberController;

--- a/zaberMotionApp/src/zaberController.cpp
+++ b/zaberMotionApp/src/zaberController.cpp
@@ -45,8 +45,10 @@ static void zaberProfileThreadC(void *pPvt) {
  * \param[in] idlePollPeriod    The time between polls when no axis is moving
  * \param[in] devicePort        The tcp or serial port that the zaber device is connected to
  * \param[in] deviceNumber      The number of the device on the port (1-indexed)
+ * \param[in] stepScaleFactor   The per-axis step size, expressed as a fraction of the driver's default motion units
+ *                              (um for linear devices and degrees for rotary).
  */
-zaberController::zaberController(const char *portName, int numAxes, double movingPollPeriod, double idlePollPeriod, const char *devicePort, int deviceNumber) :
+zaberController::zaberController(const char *portName, int numAxes, double movingPollPeriod, double idlePollPeriod, const char *devicePort, int deviceNumber, const std::vector<double> &stepScaleFactor) :
         asynMotorController(portName, numAxes, 1, 0, 0, ASYN_CANBLOCK | ASYN_MULTIDEVICE, 1 /* autoconnect */, 0, 0) {
     createParam(ZaberPulseWidthMsString, asynParamFloat64, &zaberPulseWidthMs_);
     try {
@@ -57,7 +59,11 @@ zaberController::zaberController(const char *portName, int numAxes, double movin
         fprintf(stderr, "zaberController: Initialization failed\n\t%s\n", e.what());
     }
     for(int i = 0; i < numAxes; i++) {
-        new zaberAxis(this, i);
+        double axisStepScaleFactor = 1.0;
+        if (i < static_cast<int>(stepScaleFactor.size())) {
+            axisStepScaleFactor = stepScaleFactor[i];
+        }
+        new zaberAxis(this, i, axisStepScaleFactor);
     }
     startPoller(movingPollPeriod / 1000.0, idlePollPeriod / 1000.0, 2);
 
@@ -162,7 +168,7 @@ asynStatus zaberController::buildProfile() {
             std::vector<std::optional<zml::Measurement>> positions;
             for (int axisNum : usedAxes) {
                 const zaberAxis *axis = getAxis(axisNum - 1);
-                positions.push_back(zml::Measurement{axis->profilePositions_[i] * axis->getStepScale(), axis->positionUnit_});
+                positions.push_back(zml::Measurement{axis->profilePositions_[i] * axis->stepScaleFactor_, axis->positionUnit_});
             }
             // Point 0 is the starting position.
             // This driver will move the device to this starting position when the profile is executed.
@@ -250,7 +256,7 @@ void zaberController::runProfile() {
             for (int axisNum : usedAxes) {
                 // Move to start position using device's current velocity/acceleration settings.
                 zaberAxis *axis = getAxis(axisNum - 1);
-                axis->axis_.moveAbsolute(axis->profilePositions_[0] * axis->getStepScale(), axis->positionUnit_, /*waitUntilIdle=*/true);
+                axis->axis_.moveAbsolute(axis->profilePositions_[0] * axis->stepScaleFactor_, axis->positionUnit_, /*waitUntilIdle=*/true);
             }
         }
 
@@ -326,7 +332,7 @@ asynStatus zaberController::readbackProfile() {
                 throw std::runtime_error("Attempted to access invalid axis at index: " + std::to_string(i));
             }
 
-            const double scale = axis->getStepScale();
+            const double scale = axis->stepScaleFactor_;
             std::vector<double> positions;
             positions.reserve(numPulses);
             for (int pointIndex = startPulses - 1; pointIndex <= endPulses - 1; pointIndex++) {

--- a/zaberMotionApp/src/zaberController.h
+++ b/zaberMotionApp/src/zaberController.h
@@ -2,6 +2,7 @@
 #define ZABER_BASE_CONTROLLER_H
 
 #include <memory>
+#include <vector>
 
 #include "zaberAxis.h"
 #include <asynMotorController.h>
@@ -18,7 +19,7 @@ namespace zml = zaber::motion;
 
 class epicsShareClass zaberController : public asynMotorController {
     public:
-    zaberController(const char *portName, int numAxes, double movingPollPeriod, double idlePollPeriod, const char *devicePort, int deviceNumber);
+    zaberController(const char *portName, int numAxes, double movingPollPeriod, double idlePollPeriod, const char *devicePort, int deviceNumber, const std::vector<double> &stepScaleFactor);
     void report(FILE *fp, int level) override;
 
     zaberAxis *getAxis(asynUser *pasynUser) override;

--- a/zaberMotionApp/src/zaberMotionRegister.cpp
+++ b/zaberMotionApp/src/zaberMotionRegister.cpp
@@ -4,20 +4,24 @@
 #include <epicsStdio.h>
 #include <iocsh.h>
 
+#include <vector>
+#include <string>
+
 #include "zaberController.h"
 #include "zaber/motion/library.h"
 
 // Zaber Motion Controller
 
 int zaberMotionCreateController(
-        const char *portName,   /* ZaberMotion Motor Asyn Port name */
-        int numAxes,            /* Number of axes this controller supports */
-        int movingPollPeriod,   /* Time to poll (msec) when an axis is in motion */
-        int idlePollPeriod,     /* Time to poll (msec) when an axis is idle. 0 for no polling */
-        const char *zaberPort,  /* Zaber Device TCP address or serial port name (prefixed with tcp:// or serial://) */
-        int zaberDeviceNumber   /* Zaber Device number on the port (1-indexed) */
+        const char *portName,                      /* ZaberMotion Motor Asyn Port name */
+        int numAxes,                               /* Number of axes this controller supports */
+        int movingPollPeriod,                      /* Time to poll (msec) when an axis is in motion */
+        int idlePollPeriod,                        /* Time to poll (msec) when an axis is idle. 0 for no polling */
+        const char *zaberPort,                     /* Zaber Device TCP address or serial port name (prefixed with tcp:// or serial://) */
+        int zaberDeviceNumber,                     /* Zaber Device number on the port (1-indexed) */
+        const std::vector<double> &stepScaleFactor /* Optional per-axis scaling factor applied to default step size: um (linear) or deg (rotary) -- defaults to  1.0 */
 ) {
-    zaberController *pController = new zaberController(portName, numAxes, static_cast<double>(movingPollPeriod), static_cast<double>(idlePollPeriod), zaberPort, zaberDeviceNumber);
+    zaberController *pController = new zaberController(portName, numAxes, static_cast<double>(movingPollPeriod), static_cast<double>(idlePollPeriod), zaberPort, zaberDeviceNumber, stepScaleFactor);
     (void)pController;
     return (asynSuccess);
 }
@@ -29,14 +33,26 @@ static const iocshArg zaberMotionConfigArg2 = {"moving poll rate", iocshArgInt};
 static const iocshArg zaberMotionConfigArg3 = {"idle poll rate", iocshArgInt};
 static const iocshArg zaberMotionConfigArg4 = {"zaber serial/tcp port", iocshArgString};
 static const iocshArg zaberMotionConfigArg5 = {"zaber device number", iocshArgInt};
+static const iocshArg zaberMotionConfigArg6 = {"optional per-axis step scale factor (um for linear devices, deg for rotary)", iocshArgArgv};
 
-static const iocshArg *const zaberMotionConfigArgs[6] = {&zaberMotionConfigArg0, &zaberMotionConfigArg1,
-    &zaberMotionConfigArg2, &zaberMotionConfigArg3, &zaberMotionConfigArg4, &zaberMotionConfigArg5};
+static const iocshArg *const zaberMotionConfigArgs[7] = {&zaberMotionConfigArg0, &zaberMotionConfigArg1,
+    &zaberMotionConfigArg2, &zaberMotionConfigArg3, &zaberMotionConfigArg4, &zaberMotionConfigArg5,
+    &zaberMotionConfigArg6};
 
-static const iocshFuncDef zaberMotionControllerDef = {"ZaberMotionCreateController", 6, zaberMotionConfigArgs};
+static const iocshFuncDef zaberMotionControllerDef = {"ZaberMotionCreateController", 7, zaberMotionConfigArgs};
 
 static void zaberMotionCreateControllerCallFunc(const iocshArgBuf *args) {
-    zaberMotionCreateController(args[0].sval, args[1].ival, args[2].ival, args[3].ival, args[4].sval, args[5].ival);
+    std::vector<double> stepScaleFactor;
+    for (int i = 1; i < args[6].aval.ac; i++) {
+        try {
+            stepScaleFactor.push_back(std::stod(args[6].aval.av[i]));
+        } catch (const std::exception &) {
+            printf("ZaberMotionCreateController: could not parse step scale factor '%s' for axis %d; using 1.0\n",
+                   args[6].aval.av[i], i - 1);
+            stepScaleFactor.push_back(1.0);
+        }
+    }
+    zaberMotionCreateController(args[0].sval, args[1].ival, args[2].ival, args[3].ival, args[4].sval, args[5].ival, stepScaleFactor);
 }
 
 // Create Profile


### PR DESCRIPTION
v2.1.0 modified the driver's behaviour so it now reads MRES and uses it to scale Zaber linear / rotary units under the hood. This violated the spec for the relationship between EGU and MRES. This PR proposes a general fix which allows the user to specify an optional per-axis 'scaling factor' for the default linear and rotary units (um and degrees, respectively).

If a user wants micro-degree precision for a rotary axis, they they can pass stepScalingFactor=1e-6, etc..